### PR TITLE
fix: remove stale replace directive, pin databricks-claude v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,3 @@ module github.com/IceRhymers/databricks-codex
 go 1.22
 
 require github.com/IceRhymers/databricks-claude v0.3.0
-
-// TODO: remove replace directive and update to v0.3.0 after databricks-claude#21 is merged and tagged
-replace github.com/IceRhymers/databricks-claude v0.2.0 => /tmp/dc-auth/databricks-claude


### PR DESCRIPTION
Removes the stale `replace` directive that pointed at a local dev clone. Now that databricks-claude v0.3.0 is tagged and released, the module resolves cleanly from the Go module proxy.

- go.mod: drop replace directive + TODO comment
- go.sum: updated for v0.3.0