### PR TITLE
Bump databricks-claude to v0.5.0 and expose proxy security flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.4.0
+require github.com/IceRhymers/databricks-claude v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/IceRhymers/databricks-claude v0.4.0 h1:BrL3/AWmKROeTv4dwh6pwbdM57aRJcz/CjVvfYo1zq0=
 github.com/IceRhymers/databricks-claude v0.4.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.5.0 h1:1UFNmEc5ZbqUtJDWIYqrM/80Wb2SbehyKEZVTpG0oTE=
+github.com/IceRhymers/databricks-claude v0.5.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 var Version = "dev"
 
 func main() {
-	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, codexArgs := parseArgs(os.Args[1:])
+	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, codexArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -78,6 +78,11 @@ func main() {
 	// --- Ensure the user is authenticated before proceeding ---
 	if err := authcheck.EnsureAuthenticated(profile); err != nil {
 		log.Fatalf("databricks-codex: auth failed: %v", err)
+	}
+
+	// --- TLS validation ---
+	if err := proxy.ValidateTLSConfig(tlsCert, tlsKey); err != nil {
+		log.Fatalf("databricks-codex: %v", err)
 	}
 
 	// --- Startup security checks ---
@@ -142,13 +147,20 @@ func main() {
 		UCLogsTable:       otelLogsTable,
 		TokenProvider:     tp,
 		Verbose:           verbose,
+		APIKey:            proxyAPIKey,
+		TLSCertFile:       tlsCert,
+		TLSKeyFile:        tlsKey,
 	})
-	listener, err := StartProxy(proxyHandler)
+	listener, err := StartProxy(proxyHandler, tlsCert, tlsKey)
 	if err != nil {
 		log.Fatalf("databricks-codex: failed to start proxy: %v", err)
 	}
 	defer listener.Close()
-	proxyAddr := "http://" + listener.Addr().String()
+	proxyScheme := "http://"
+	if tlsCert != "" && tlsKey != "" {
+		proxyScheme = "https://"
+	}
+	proxyAddr := proxyScheme + listener.Addr().String()
 	log.Printf("databricks-codex: local proxy %s -> %s", proxyAddr, gatewayURL)
 
 	// --- Patch config.toml to point Codex at the local proxy ---
@@ -190,7 +202,7 @@ func main() {
 }
 
 // parseArgs separates databricks-codex flags from codex flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, codexArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, codexArgs []string) {
 	knownFlags := map[string]bool{
 		"--verbose":         true,
 		"--version":         true,
@@ -202,6 +214,9 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 		"--upstream":        true,
 		"--log-file":        true,
 		"--profile":         true,
+		"--proxy-api-key":   true,
+		"--tls-cert":        true,
+		"--tls-key":         true,
 	}
 
 	i := 0
@@ -265,6 +280,27 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 						i++
 						profile = args[i]
 					}
+				case "--proxy-api-key":
+					if value != "" {
+						proxyAPIKey = value
+					} else if i+1 < len(args) {
+						i++
+						proxyAPIKey = args[i]
+					}
+				case "--tls-cert":
+					if value != "" {
+						tlsCert = value
+					} else if i+1 < len(args) {
+						i++
+						tlsCert = args[i]
+					}
+				case "--tls-key":
+					if value != "" {
+						tlsKey = value
+					} else if i+1 < len(args) {
+						i++
+						tlsKey = args[i]
+					}
 				case "--verbose":
 					verbose = true
 				case "--version":
@@ -309,6 +345,9 @@ Databricks-Codex Flags:
   --otel                    Enable OpenTelemetry log export
   --no-otel                 Disable OpenTelemetry for this session
   --otel-logs-table string  Unity Catalog table for OTEL logs (default: main.codex_telemetry.codex_otel_logs)
+  --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
+  --tls-cert string         Path to TLS certificate file (requires --tls-key)
+  --tls-key string          Path to TLS private key file (requires --tls-cert)
   --version             Print version and exit
   --help, -h            Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, codexArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, codexArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -23,70 +23,70 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, noOtel, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -100,7 +100,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 
 
 func TestParseArgs_OtelLogsTable(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
 	if !otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=true when --otel-logs-table is passed")
 	}
@@ -109,7 +109,7 @@ func TestParseArgs_OtelLogsTable(t *testing.T) {
 	}
 }
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _ := parseArgs([]string{})
 	if otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -118,14 +118,14 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
 	if len(codexArgs) != 1 || codexArgs[0] != "--unknown" {
 		t.Errorf("expected codexArgs=[\"--unknown\"], got %v", codexArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, codexArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, codexArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv || noOtel || otel {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -144,7 +144,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -157,7 +157,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -167,7 +167,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--model", "gpt-4"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--model", "gpt-4"})
 	if len(codexArgs) != 3 {
 		t.Errorf("expected 3 codexArgs, got %d: %v", len(codexArgs), codexArgs)
 	}
@@ -282,7 +282,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, codexArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, codexArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -433,21 +433,21 @@ func TestHandleHelp_ContainsCodexCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, otel, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -15,6 +15,9 @@ type ProxyConfig struct {
 	UCLogsTable       string
 	TokenProvider     *tokencache.TokenProvider
 	Verbose           bool
+	APIKey            string
+	TLSCertFile       string
+	TLSKeyFile        string
 }
 
 // NewProxyServer returns an http.Handler that routes requests to the
@@ -26,11 +29,15 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 		UCLogsTable:       config.UCLogsTable,
 		TokenSource:       config.TokenProvider,
 		Verbose:           config.Verbose,
+		APIKey:            config.APIKey,
+		TLSCertFile:       config.TLSCertFile,
+		TLSKeyFile:        config.TLSKeyFile,
 	})
 }
 
 // StartProxy binds to 127.0.0.1:0, starts serving, and returns the listener.
 // Callers read l.Addr() to discover the assigned port.
-func StartProxy(handler http.Handler) (net.Listener, error) {
-	return proxy.Start(handler)
+// When certFile and keyFile are both non-empty, the listener serves TLS.
+func StartProxy(handler http.Handler, certFile, keyFile string) (net.Listener, error) {
+	return proxy.Start(handler, certFile, keyFile)
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -195,7 +195,7 @@ func TestProxy_SSEStreaming(t *testing.T) {
 	}
 	handler := NewProxyServer(cfg)
 
-	l, err := StartProxy(handler)
+	l, err := StartProxy(handler, "", "")
 	if err != nil {
 		t.Fatalf("StartProxy: %v", err)
 	}


### PR DESCRIPTION
## Summary
• Bumps `github.com/IceRhymers/databricks-claude` from v0.4.0 to v0.5.0
• Adds `--proxy-api-key` flag to require API key authentication on all local proxy requests
• Adds `--tls-cert` and `--tls-key` flags to enable HTTPS on the local proxy listener
• Validates TLS config at startup (cert and key must be provided together)
• Updates proxy address scheme to `https://` when TLS is active
• Adapts to updated `proxy.Start()` signature (now accepts certFile, keyFile params)

## Test plan
• `go build ./...` passes
• `go test ./...` passes (all existing tests updated for new parseArgs signature)
• `go vet ./...` passes
• Manual: run with `--proxy-api-key=secret` and verify unauthenticated requests are rejected
• Manual: run with `--tls-cert` only and verify fatal error about missing `--tls-key`
• Manual: run with both `--tls-cert` and `--tls-key` and verify proxy listens on https://

🤖 Generated with [Claude Code](https://claude.com/claude-code)