### PR TITLE
feat: fixed-port session management (port 49154)

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/IceRhymers/databricks-claude/pkg/filelock"
 	"github.com/IceRhymers/databricks-claude/pkg/registry"
@@ -65,6 +66,61 @@ func (cm *ConfigManager) Setup(proxyURL, model string, modelExplicit bool, otelE
 	}
 
 	log.Printf("databricks-codex: patched %s (proxy: %s)", cm.config.ConfigPath(), proxyURL)
+	return nil
+}
+
+// EnsureConfig is an idempotent config writer. It reads ~/.codex/config.toml,
+// checks if the model_providers.databricks-proxy base_url already equals proxyURL,
+// and if so returns nil (no-op). Otherwise it performs a full Setup-style patch.
+// Unlike Setup/Restore, this does NOT create a backup or register a session —
+// the config persists pointing at the fixed port permanently.
+func (cm *ConfigManager) EnsureConfig(proxyURL, model string, modelExplicit bool, otelEndpoint string) error {
+	if err := cm.lock.Lock(); err != nil {
+		log.Printf("databricks-codex: config lock warning: %v", err)
+	}
+	defer cm.lock.Unlock()
+
+	// Read existing config to check idempotency.
+	existing, _ := os.ReadFile(cm.config.ConfigPath())
+	if existing != nil {
+		// Check if base_url already matches proxyURL.
+		for _, line := range strings.Split(string(existing), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "base_url") && strings.Contains(trimmed, "=") {
+				parts := strings.SplitN(trimmed, "=", 2)
+				if len(parts) == 2 {
+					val := strings.TrimSpace(parts[1])
+					val = strings.Trim(val, `"`)
+					if val == proxyURL {
+						log.Printf("databricks-codex: config.toml already configured for %s", proxyURL)
+						return nil
+					}
+				}
+			}
+		}
+	}
+
+	// Not yet configured — patch config.toml.
+	// Store original for the patch method (it reads m.original).
+	cm.config.RestoreFromBackup() // recover from any previous crash
+
+	if err := cm.config.Backup(); err != nil {
+		return err
+	}
+
+	if err := cm.config.Patch(tomlconfig.PatchConfig{
+		ProxyURL:      proxyURL,
+		Model:         model,
+		ModelExplicit: modelExplicit,
+		OTELEndpoint:  otelEndpoint,
+	}); err != nil {
+		return err
+	}
+
+	// Remove the backup — we want the config to persist.
+	os.Remove(cm.config.ConfigPath() + ".databricks-codex-backup")
+
+	log.Printf("databricks-codex: wrote config.toml (proxy: %s)", proxyURL)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.5.0
+require github.com/IceRhymers/databricks-claude v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.4.0 h1:BrL3/AWmKROeTv4dwh6pwbdM57aRJcz/CjVvfYo1zq0=
-github.com/IceRhymers/databricks-claude v0.4.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
-github.com/IceRhymers/databricks-claude v0.5.0 h1:1UFNmEc5ZbqUtJDWIYqrM/80Wb2SbehyKEZVTpG0oTE=
-github.com/IceRhymers/databricks-claude v0.5.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.6.0 h1:0dA07ibYTqbw0FgYkmLPHuAalRAeVajHOTdVLreyLYc=
+github.com/IceRhymers/databricks-claude v0.6.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=

--- a/main.go
+++ b/main.go
@@ -7,18 +7,24 @@ import (
 	"io"
 	"log"
 	"os"
+	"net"
+	"net/http"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
+	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
 // Version is set at build time via -ldflags.
 var Version = "dev"
 
 func main() {
-	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, codexArgs := parseArgs(os.Args[1:])
+	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, codexArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -105,6 +111,19 @@ func main() {
 		log.Fatalf("databricks-codex: auth failed: %v", err)
 	}
 
+	// --- Load state and resolve port ---
+	state := loadState()
+	port := resolvePort(portFlag, state)
+	if portFlag > 0 {
+		state.Port = port
+		if err := saveState(state); err != nil {
+			log.Printf("databricks-codex: failed to save port: %v", err)
+		} else {
+			log.Printf("databricks-codex: saved port %d for future sessions", port)
+		}
+	}
+	log.Printf("databricks-codex: using port: %d", port)
+
 	// --- TLS validation ---
 	if err := proxy.ValidateTLSConfig(tlsCert, tlsKey); err != nil {
 		log.Fatalf("databricks-codex: %v", err)
@@ -173,45 +192,71 @@ func main() {
 		log.Printf("databricks-codex: OTEL enabled, upstream: %s", otelUpstream)
 	}
 
-	// --- Start local proxy so the token stays fresh for the entire session ---
-	// The proxy uses tokencache to refresh the Databricks OAuth token automatically
-	// (5-min buffer before expiry). Codex talks to the proxy via config.toml;
-	// the proxy injects a fresh Bearer token on every outbound request/WebSocket
-	// connection to the AI Gateway.
-	proxyHandler := NewProxyServer(&ProxyConfig{
-		InferenceUpstream: gatewayURL,
-		OTELUpstream:      otelUpstream,
-		UCLogsTable:       otelLogsTable,
-		TokenProvider:     tp,
-		Verbose:           verbose,
-		APIKey:            proxyAPIKey,
-		TLSCertFile:       tlsCert,
-		TLSKeyFile:        tlsKey,
-	})
-	listener, err := StartProxy(proxyHandler, tlsCert, tlsKey)
+	// --- Bind proxy port ---
+	ln, isOwner, err := portbind.Bind("databricks-codex", port)
 	if err != nil {
-		log.Fatalf("databricks-codex: failed to start proxy: %v", err)
+		log.Fatalf("databricks-codex: %v", err)
 	}
-	defer listener.Close()
-	proxyScheme := "http://"
-	if tlsCert != "" && tlsKey != "" {
-		proxyScheme = "https://"
-	}
-	proxyAddr := proxyScheme + listener.Addr().String()
-	log.Printf("databricks-codex: local proxy %s -> %s", proxyAddr, gatewayURL)
 
-	// --- Patch config.toml to point Codex at the local proxy ---
-	// This is the Codex equivalent of databricks-claude patching settings.json.
-	// The proxy URL is written as a model_provider in config.toml with
-	// wire_api = "responses" so Codex uses the Responses API via WebSocket.
+	scheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		scheme = "https"
+		fmt.Fprintln(os.Stderr, "databricks-codex: TLS enabled")
+	}
+	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, listenerPort(ln, port))
+
+	// --- Start proxy if we own the port ---
+	if isOwner {
+		proxyCfg := &ProxyConfig{
+			InferenceUpstream: gatewayURL,
+			OTELUpstream:      otelUpstream,
+			UCLogsTable:       otelLogsTable,
+			TokenProvider:     tp,
+			Verbose:           verbose,
+			APIKey:            proxyAPIKey,
+			TLSCertFile:       tlsCert,
+			TLSKeyFile:        tlsKey,
+			ToolName:          "databricks-codex",
+			Version:           Version,
+		}
+		if proxyAPIKey != "" {
+			fmt.Fprintln(os.Stderr, "databricks-codex: proxy API key authentication enabled")
+		}
+		handler := NewProxyServer(proxyCfg)
+		go func() {
+			srv := &http.Server{Handler: handler}
+			if tlsCert != "" && tlsKey != "" {
+				if err := srv.ServeTLS(ln, tlsCert, tlsKey); err != nil && err != http.ErrServerClosed {
+					log.Printf("databricks-codex: proxy serve error: %v", err)
+				}
+			} else {
+				if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+					log.Printf("databricks-codex: proxy serve error: %v", err)
+				}
+			}
+		}()
+	}
+	log.Printf("databricks-codex: proxy on %s (owner=%v)", proxyURL, isOwner)
+
+	// --- Reference counting ---
+	refcountPath := filepath.Join(os.TempDir(), fmt.Sprintf(".databricks-codex-sessions-%d", port))
+	refcount.Acquire(refcountPath)
+	defer func() {
+		n, _ := refcount.Release(refcountPath)
+		if n == 0 && isOwner {
+			ln.Close()
+		}
+	}()
+
+	// --- Write config once (idempotent) ---
 	otelConfigEndpoint := ""
 	if otel {
-		otelConfigEndpoint = proxyAddr + "/otel/v1/logs"
+		otelConfigEndpoint = proxyURL + "/otel/v1/logs"
 	}
 
 	cm := NewConfigManager()
-	if err := cm.Setup(proxyAddr, model, modelExplicit, otelConfigEndpoint); err != nil {
-		log.Fatalf("databricks-codex: failed to patch config.toml: %v", err)
+	if err := cm.EnsureConfig(proxyURL, model, modelExplicit, otelConfigEndpoint); err != nil {
+		log.Fatalf("databricks-codex: failed to write config.toml: %v", err)
 	}
 
 	// Set OPENAI_API_KEY as a placeholder — the proxy overwrites the
@@ -227,19 +272,26 @@ func main() {
 	// --- Run codex as a child process (parent stays alive to serve the proxy) ---
 	exitCode, err := RunCodex(context.Background(), codexArgs)
 
-	// Explicitly restore config.toml before exiting. This is NOT deferred
-	// because os.Exit() skips deferred functions — we must restore before
-	// exit to avoid leaving config.toml pointing at a dead proxy.
-	cm.Restore()
-
 	if err != nil {
-		log.Fatalf("databricks-codex: codex failed: %v", err)
+		log.Printf("databricks-codex: codex error: %v", err)
 	}
 	os.Exit(exitCode)
 }
 
+// listenerPort extracts the port from a net.Listener, falling back to the
+// configured port if the listener is nil (e.g., non-owner case).
+func listenerPort(ln net.Listener, fallback int) int {
+	if ln == nil {
+		return fallback
+	}
+	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return fallback
+}
+
 // parseArgs separates databricks-codex flags from codex flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, codexArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, codexArgs []string) {
 	knownFlags := map[string]bool{
 		"--verbose":         true,
 		"--version":         true,
@@ -255,6 +307,7 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 		"--tls-cert":        true,
 		"--tls-key":         true,
 		"--model":           true,
+		"--port":            true,
 	}
 
 	i := 0
@@ -360,6 +413,13 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 					otel = true
 				case "--no-otel":
 					noOtel = true
+				case "--port":
+					if value != "" {
+						portFlag, _ = strconv.Atoi(value)
+					} else if i+1 < len(args) {
+						i++
+						portFlag, _ = strconv.Atoi(args[i])
+					}
 				}
 				i++
 				continue
@@ -396,6 +456,7 @@ Databricks-Codex Flags:
   --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
+  --port int                Fixed proxy port (default: 49154, saved to state)
   --version             Print version and exit
   --help, -h            Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -23,70 +23,70 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -96,7 +96,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTable(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
 	if !otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=true when --otel-logs-table is passed")
 	}
@@ -105,7 +105,7 @@ func TestParseArgs_OtelLogsTable(t *testing.T) {
 	}
 }
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
 	if otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -113,14 +113,14 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
 	if len(codexArgs) != 1 || codexArgs[0] != "--unknown" {
 		t.Errorf("expected codexArgs=[\"--unknown\"], got %v", codexArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, codexArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, codexArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv || noOtel || otel {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -139,7 +139,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -152,7 +152,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -162,7 +162,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
 	if len(codexArgs) != 3 {
 		t.Errorf("expected 3 codexArgs, got %d: %v", len(codexArgs), codexArgs)
 	}
@@ -171,7 +171,7 @@ func TestParseArgs_PassthroughArgs(t *testing.T) {
 // --- Model flag tests ---
 
 func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model is passed")
 	}
@@ -181,7 +181,7 @@ func TestParseArgs_Model(t *testing.T) {
 }
 
 func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _ := parseArgs([]string{"--model=custom-model"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model=custom-model"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model=value is passed")
 	}
@@ -191,7 +191,7 @@ func TestParseArgs_ModelEquals(t *testing.T) {
 }
 
 func TestParseArgs_ModelDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _ := parseArgs([]string{})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{})
 	if modelSet {
 		t.Error("expected modelSet=false when --model is not passed")
 	}
@@ -201,7 +201,7 @@ func TestParseArgs_ModelDefault(t *testing.T) {
 }
 
 func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
 	if !modelSet {
 		t.Error("expected modelSet=true")
 	}
@@ -227,6 +227,7 @@ func TestParseArgs_Table(t *testing.T) {
 		otel     bool
 		model    string
 		modelSet bool
+		portFlag int
 		codexLen int
 	}
 
@@ -330,11 +331,21 @@ func TestParseArgs_Table(t *testing.T) {
 			args: []string{"--model=my-model"},
 			want: result{model: "my-model", modelSet: true},
 		},
+		{
+			name: "--port sets portFlag",
+			args: []string{"--port", "9999"},
+			want: result{portFlag: 9999},
+		},
+		{
+			name: "--port=value sets portFlag",
+			args: []string{"--port=8080"},
+			want: result{portFlag: 8080},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, codexArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, portFlag, codexArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -368,6 +379,9 @@ func TestParseArgs_Table(t *testing.T) {
 			}
 			if modelSet != tc.want.modelSet {
 				t.Errorf("modelSet: got %v, want %v", modelSet, tc.want.modelSet)
+			}
+			if portFlag != tc.want.portFlag {
+				t.Errorf("portFlag: got %d, want %d", portFlag, tc.want.portFlag)
 			}
 			if len(codexArgs) != tc.want.codexLen {
 				t.Errorf("codexArgs length: got %d, want %d (args: %v)", len(codexArgs), tc.want.codexLen, codexArgs)
@@ -503,21 +517,21 @@ func TestHandleHelp_ContainsCodexCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -527,7 +541,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--version", "--help"}
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)

--- a/proxy.go
+++ b/proxy.go
@@ -18,6 +18,8 @@ type ProxyConfig struct {
 	APIKey            string
 	TLSCertFile       string
 	TLSKeyFile        string
+	ToolName          string // reported by /health endpoint
+	Version           string // reported by /health endpoint
 }
 
 // NewProxyServer returns an http.Handler that routes requests to the
@@ -32,7 +34,16 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 		APIKey:            config.APIKey,
 		TLSCertFile:       config.TLSCertFile,
 		TLSKeyFile:        config.TLSKeyFile,
+		ToolName:          config.ToolName,
+		Version:           config.Version,
 	})
+}
+
+// ServeProxy starts the proxy on the given listener.
+// When config.TLSCertFile and config.TLSKeyFile are both set, the listener serves TLS.
+func ServeProxy(config *ProxyConfig, handler http.Handler, ln net.Listener) error {
+	_, err := proxy.Serve(ln, handler, config.TLSCertFile, config.TLSKeyFile)
+	return err
 }
 
 // StartProxy binds to 127.0.0.1:0, starts serving, and returns the listener.

--- a/state.go
+++ b/state.go
@@ -13,6 +13,23 @@ type persistentState struct {
 	Profile       string `json:"profile,omitempty"`
 	OtelLogsTable string `json:"otel_logs_table,omitempty"`
 	Model         string `json:"model,omitempty"`
+	Port          int    `json:"port,omitempty"`
+}
+
+const defaultPort = 49154
+
+// resolvePort returns the port to use, following the resolution chain:
+// 1. --port flag (portFlag > 0)
+// 2. Saved state value (non-zero)
+// 3. Default 49154
+func resolvePort(portFlag int, state persistentState) int {
+	if portFlag > 0 {
+		return portFlag
+	}
+	if state.Port > 0 {
+		return state.Port
+	}
+	return defaultPort
 }
 
 // statePath returns the path to the persistent state file.

--- a/state_test.go
+++ b/state_test.go
@@ -160,3 +160,41 @@ func TestSaveState_ModelPreservesOtherFields(t *testing.T) {
 		t.Errorf("got Model %q, want %q", s.Model, "custom-model")
 	}
 }
+
+func TestResolvePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		portFlag int
+		state    persistentState
+		want     int
+	}{
+		{"flag wins", 9999, persistentState{Port: 8080}, 9999},
+		{"state wins over default", 0, persistentState{Port: 8080}, 8080},
+		{"default when no flag and no state", 0, persistentState{}, defaultPort},
+		{"flag wins over default", 5555, persistentState{}, 5555},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolvePort(tc.portFlag, tc.state)
+			if got != tc.want {
+				t.Errorf("resolvePort(%d, %+v) = %d, want %d", tc.portFlag, tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadState_Port(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	if err := saveState(persistentState{Port: 49154}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	s := loadState()
+	if s.Port != 49154 {
+		t.Errorf("got Port %d, want %d", s.Port, 49154)
+	}
+}


### PR DESCRIPTION
Closes #17

Switches from dynamic-port + config save/restore to fixed port 49154 with first-writer-wins proxy ownership and file-based ref-counting.

- portbind.Bind("databricks-codex", 49154): tries fixed port, falls back to ephemeral on collision
- refcount tracks concurrent sessions; last session closes listener
- ensureConfig writes TOML only once (idempotent)
- No crash recovery needed: config always points at fixed port

🤖 Generated with Claude Code