### PR TITLE
fix: profile resolution — state file wins over env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,21 +57,13 @@ func main() {
 	}
 
 	// --- Resolve profile ---
-	// Resolution chain: --profile flag → env var → saved state → "DEFAULT".
+	// Resolution chain: --profile flag → saved state → "DEFAULT".
+	// The env var DATABRICKS_CONFIG_PROFILE is intentionally NOT checked here;
+	// injected env vars (e.g. from Claude's settings.json) would silently
+	// override the user's saved proxy profile, routing to the wrong workspace.
 	// When --profile is explicitly passed, save it for future sessions.
 	profileExplicit := profile != ""
-	if profile == "" {
-		profile = os.Getenv("DATABRICKS_CONFIG_PROFILE")
-	}
-	if profile == "" {
-		if saved := loadState(); saved.Profile != "" {
-			profile = saved.Profile
-			log.Printf("databricks-codex: using saved profile: %s", profile)
-		}
-	}
-	if profile == "" {
-		profile = "DEFAULT"
-	}
+	profile = resolveProfile(profile, loadState().Profile)
 	if profileExplicit {
 		saved := loadState()
 		saved.Profile = profile
@@ -505,6 +497,20 @@ func handlePrintEnv(databricksHost, openaiBaseURL, token, profile, model, otelLo
   OTEL Logs Table:   %s
   Codex binary:      %s
 `, profile, model, databricksHost, openaiBaseURL, redacted, otelLogsTable, codexPath)
+}
+
+// resolveProfile returns the Databricks CLI profile using the resolution chain:
+// --profile flag → saved state → "DEFAULT".
+// The env var DATABRICKS_CONFIG_PROFILE is intentionally skipped; injected env
+// vars would silently override the user's saved proxy profile.
+func resolveProfile(flagValue string, savedValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if savedValue != "" {
+		return savedValue
+	}
+	return "DEFAULT"
 }
 
 // resolveOtelLogsTable returns the OTEL logs table using the resolution chain:

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -622,5 +623,97 @@ func TestHandlePrintEnv_ContainsOtelLogsTable(t *testing.T) {
 	}
 	if !strings.Contains(out, "OTEL Logs Table:") {
 		t.Errorf("expected output to contain 'OTEL Logs Table:' label, got:\n%s", out)
+	}
+}
+
+// --- resolveProfile tests ---
+
+func TestResolveProfile_FlagWinsOverStateFile(t *testing.T) {
+	got := resolveProfile("from-flag", "from-state")
+	if got != "from-flag" {
+		t.Errorf("expected flag value %q, got %q", "from-flag", got)
+	}
+}
+
+func TestResolveProfile_StateFileWinsOverEnvVar(t *testing.T) {
+	// Set the env var that previously would have won over state file.
+	t.Setenv("DATABRICKS_CONFIG_PROFILE", "from-env")
+
+	// resolveProfile should use saved state, ignoring the env var entirely.
+	got := resolveProfile("", "from-state")
+	if got != "from-state" {
+		t.Errorf("expected state file value %q, got %q — env var should be ignored", "from-state", got)
+	}
+}
+
+func TestResolveProfile_FallsBackToDefault(t *testing.T) {
+	got := resolveProfile("", "")
+	if got != "DEFAULT" {
+		t.Errorf("expected %q, got %q", "DEFAULT", got)
+	}
+}
+
+func TestResolveProfile_FlagWinsOverStateFile_Integration(t *testing.T) {
+	// Wire up a temp state file with a saved profile.
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "saved-profile"})
+
+	// Simulate --profile flag being passed.
+	got := resolveProfile("flag-profile", loadState().Profile)
+	if got != "flag-profile" {
+		t.Errorf("expected flag profile %q, got %q", "flag-profile", got)
+	}
+}
+
+func TestResolveProfile_StateFileUsedWhenNoFlag(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "saved-profile"})
+
+	got := resolveProfile("", loadState().Profile)
+	if got != "saved-profile" {
+		t.Errorf("expected saved profile %q, got %q", "saved-profile", got)
+	}
+}
+
+func TestResolveProfile_DefaultWhenNoStateFile(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "nonexistent.json") }
+	defer func() { statePath = orig }()
+
+	got := resolveProfile("", loadState().Profile)
+	if got != "DEFAULT" {
+		t.Errorf("expected %q, got %q", "DEFAULT", got)
+	}
+}
+
+func TestResolveProfile_Table(t *testing.T) {
+	tests := []struct {
+		name       string
+		flagValue  string
+		savedValue string
+		want       string
+	}{
+		{"flag wins over saved", "flag-profile", "saved-profile", "flag-profile"},
+		{"saved wins over default", "", "saved-profile", "saved-profile"},
+		{"default when both empty", "", "", "DEFAULT"},
+		{"flag wins over empty saved", "flag-profile", "", "flag-profile"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveProfile(tc.flagValue, tc.savedValue)
+			if got != tc.want {
+				t.Errorf("resolveProfile(%q, %q) = %q, want %q",
+					tc.flagValue, tc.savedValue, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Removes `DATABRICKS_CONFIG_PROFILE` env var from the profile resolution chain. When injected by external tools (e.g. Claude's settings.json), it silently overrode the user's saved proxy profile, routing inference to the wrong workspace.
- Resolution chain is now: `--profile flag → saved state → "DEFAULT"`
- Extracts `resolveProfile()` function (matching existing `resolvePort`/`resolveOtelLogsTable` pattern) with full test coverage

## Test plan

- [x] `go test ./...` passes (all existing + 10 new profile resolution tests)
- [x] `go build ./...` compiles cleanly
- [ ] Manual: set `DATABRICKS_CONFIG_PROFILE=wrong` in env, save a profile via `--profile correct`, verify subsequent runs use `correct` from state file

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)