### PR TITLE
fix: add proxy recovery for concurrent sessions

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,14 +61,9 @@ func (cm *ConfigManager) EnsureConfig(proxyURL, model string, modelExplicit bool
 		}
 	}
 
-	// Not yet configured — patch config.toml.
-	// Store original for the patch method (it reads m.original).
-	cm.config.RestoreFromBackup() // recover from any previous crash
-
-	if err := cm.config.Backup(); err != nil {
-		return err
-	}
-
+	// Not yet configured — patch config.toml directly.
+	// No backup/restore needed: the fixed-port design means EnsureConfig is
+	// self-healing on next boot (same URL every time).
 	if err := cm.config.Patch(tomlconfig.PatchConfig{
 		ProxyURL:      proxyURL,
 		Model:         model,
@@ -78,7 +73,7 @@ func (cm *ConfigManager) EnsureConfig(proxyURL, model string, modelExplicit bool
 		return err
 	}
 
-	// Remove the backup — we want the config to persist.
+	// Clean up any stale backup from pre-v0.6.0 crash recovery.
 	os.Remove(cm.config.ConfigPath() + ".databricks-codex-backup")
 
 	log.Printf("databricks-codex: wrote config.toml (proxy: %s)", proxyURL)

--- a/main.go
+++ b/main.go
@@ -3,16 +3,18 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
@@ -185,7 +187,7 @@ func main() {
 	}
 
 	// --- Bind proxy port ---
-	ln, isOwner, err := portbind.Bind("databricks-codex", port)
+	listener, isOwner, err := portbind.Bind("databricks-codex", port)
 	if err != nil {
 		log.Fatalf("databricks-codex: %v", err)
 	}
@@ -195,50 +197,45 @@ func main() {
 		scheme = "https"
 		fmt.Fprintln(os.Stderr, "databricks-codex: TLS enabled")
 	}
-	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, listenerPort(ln, port))
+	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, listenerPort(listener, port))
+
+	// --- Proxy handler (needed by owner and recovery goroutine) ---
+	if proxyAPIKey != "" {
+		fmt.Fprintln(os.Stderr, "databricks-codex: proxy API key authentication enabled")
+	}
+	proxyHandler := NewProxyServer(&ProxyConfig{
+		InferenceUpstream: gatewayURL,
+		OTELUpstream:      otelUpstream,
+		UCLogsTable:       otelLogsTable,
+		TokenProvider:     tp,
+		Verbose:           verbose,
+		APIKey:            proxyAPIKey,
+		TLSCertFile:       tlsCert,
+		TLSKeyFile:        tlsKey,
+		ToolName:          "databricks-codex",
+		Version:           Version,
+	})
 
 	// --- Start proxy if we own the port ---
 	if isOwner {
-		proxyCfg := &ProxyConfig{
-			InferenceUpstream: gatewayURL,
-			OTELUpstream:      otelUpstream,
-			UCLogsTable:       otelLogsTable,
-			TokenProvider:     tp,
-			Verbose:           verbose,
-			APIKey:            proxyAPIKey,
-			TLSCertFile:       tlsCert,
-			TLSKeyFile:        tlsKey,
-			ToolName:          "databricks-codex",
-			Version:           Version,
+		servedLn, err := proxy.Serve(listener, proxyHandler, tlsCert, tlsKey)
+		if err != nil {
+			log.Fatalf("databricks-codex: failed to start proxy: %v", err)
 		}
-		if proxyAPIKey != "" {
-			fmt.Fprintln(os.Stderr, "databricks-codex: proxy API key authentication enabled")
-		}
-		handler := NewProxyServer(proxyCfg)
-		go func() {
-			srv := &http.Server{Handler: handler}
-			if tlsCert != "" && tlsKey != "" {
-				if err := srv.ServeTLS(ln, tlsCert, tlsKey); err != nil && err != http.ErrServerClosed {
-					log.Printf("databricks-codex: proxy serve error: %v", err)
-				}
-			} else {
-				if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
-					log.Printf("databricks-codex: proxy serve error: %v", err)
-				}
-			}
-		}()
+		listener = servedLn
+		log.Printf("databricks-codex: proxy owner on :%d", port)
+	} else {
+		log.Printf("databricks-codex: joining existing proxy on :%d", port)
+		// Watch for owner death and take over the proxy if needed.
+		go watchProxy(port, proxyHandler, tlsCert, tlsKey)
 	}
 	log.Printf("databricks-codex: proxy on %s (owner=%v)", proxyURL, isOwner)
 
 	// --- Reference counting ---
 	refcountPath := filepath.Join(os.TempDir(), fmt.Sprintf(".databricks-codex-sessions-%d", port))
-	refcount.Acquire(refcountPath)
-	defer func() {
-		n, _ := refcount.Release(refcountPath)
-		if n == 0 && isOwner {
-			ln.Close()
-		}
-	}()
+	if err := refcount.Acquire(refcountPath); err != nil {
+		log.Printf("databricks-codex: refcount acquire warning: %v", err)
+	}
 
 	// --- Write config once (idempotent) ---
 	otelConfigEndpoint := ""
@@ -262,10 +259,20 @@ func main() {
 	log.Printf("databricks-codex: launching codex")
 
 	// --- Run codex as a child process (parent stays alive to serve the proxy) ---
-	exitCode, err := RunCodex(context.Background(), codexArgs)
+	exitCode, runErr := RunCodex(context.Background(), codexArgs)
 
+	// --- Release refcount; if last session and owner, close listener ---
+	remaining, err := refcount.Release(refcountPath)
 	if err != nil {
-		log.Printf("databricks-codex: codex error: %v", err)
+		log.Printf("databricks-codex: refcount release warning: %v", err)
+	}
+	if remaining == 0 && isOwner {
+		listener.Close()
+		log.Printf("databricks-codex: last session, proxy shut down")
+	}
+
+	if runErr != nil {
+		log.Printf("databricks-codex: codex error: %v", runErr)
 	}
 	os.Exit(exitCode)
 }
@@ -280,6 +287,52 @@ func listenerPort(ln net.Listener, fallback int) int {
 		return addr.Port
 	}
 	return fallback
+}
+
+// proxyHealthy returns true if the proxy on the given port responds to /health.
+func proxyHealthy(port int, scheme string) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	if scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// watchProxy polls the proxy health endpoint and takes over the port if the
+// owner process dies. Runs as a goroutine for non-owner sessions.
+func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
+	scheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		scheme = "https"
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if proxyHealthy(port, scheme) {
+			continue
+		}
+
+		// Proxy is unreachable — try to bind the port and take over.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue // another session grabbed it first
+		}
+		if _, err := proxy.Serve(ln, handler, tlsCert, tlsKey); err != nil {
+			ln.Close()
+			continue
+		}
+		log.Printf("databricks-codex: proxy owner died, took over on :%d", port)
+		return
+	}
 }
 
 // parseArgs separates databricks-codex flags from codex flags.

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -98,6 +98,8 @@ func (m *Manager) Patch(cfg PatchConfig) error {
 	content := ""
 	if m.original != nil {
 		content = string(m.original)
+	} else if data, err := os.ReadFile(m.configPath); err == nil {
+		content = string(data)
 	}
 
 	// --- Save originals and patch root keys ---


### PR DESCRIPTION
## Summary

- Adds a `watchProxy` goroutine for non-owner sessions that polls `/health` every 2s and re-binds the port if the proxy owner dies
- Moves proxy handler creation outside the `isOwner` branch so recovery can start a new proxy with the same config
- Calls `refcount.Release` explicitly before `os.Exit` instead of relying on deferred cleanup (`os.Exit` bypasses defers)
- Simplifies `EnsureConfig` — removes unnecessary backup/restore cycle
- Uses `proxy.Serve` from the shared package instead of raw goroutine

Matches the pattern used in databricks-opencode.

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Two concurrent sessions: exit session 1 (owner), session 2 recovers within 2s
- [ ] Two concurrent sessions: exit session 2, session 1 unaffected
- [ ] Single session: normal start/stop lifecycle unchanged

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)