### PR TITLE
feat: --headless mode for proxy-only startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
@@ -26,7 +28,7 @@ import (
 var Version = "dev"
 
 func main() {
-	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, codexArgs := parseArgs(os.Args[1:])
+	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, headless, codexArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -174,9 +176,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Verify codex is on PATH before starting proxy.
-	if _, err := exec.LookPath("codex"); err != nil {
-		log.Fatalf("databricks-codex: codex binary not found on PATH — install from https://openai.com/codex")
+	// Verify codex is on PATH before starting proxy (skip in headless mode).
+	if !headless {
+		if _, err := exec.LookPath("codex"); err != nil {
+			log.Fatalf("databricks-codex: codex binary not found on PATH — install from https://openai.com/codex")
+		}
 	}
 
 	// --- Determine OTEL upstream ---
@@ -245,7 +249,17 @@ func main() {
 
 	cm := NewConfigManager()
 	if err := cm.EnsureConfig(proxyURL, model, modelExplicit, otelConfigEndpoint); err != nil {
-		log.Fatalf("databricks-codex: failed to write config.toml: %v", err)
+		if headless {
+			log.Printf("databricks-codex: warning: failed to write config.toml: %v", err)
+		} else {
+			log.Fatalf("databricks-codex: failed to write config.toml: %v", err)
+		}
+	}
+
+	// --- Headless mode: print proxy URL and wait for signal ---
+	if headless {
+		runHeadless(proxyURL, listener, isOwner, refcountPath)
+		return
 	}
 
 	// Set OPENAI_API_KEY as a placeholder — the proxy overwrites the
@@ -275,6 +289,28 @@ func main() {
 		log.Printf("databricks-codex: codex error: %v", runErr)
 	}
 	os.Exit(exitCode)
+}
+
+// runHeadless runs the proxy in headless mode: prints PROXY_URL to stdout,
+// then blocks until SIGINT or SIGTERM. Intended for IDE extensions that
+// manage their own codex process.
+func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath string) {
+	if !isOwner {
+		// Non-owner: watch for proxy death and take over if needed.
+		// watchProxy is already defined in this file.
+		// We don't have the handler/TLS args here, so the non-owner
+		// headless case simply watches — recovery requires the proxy
+		// config which only the owner path sets up.
+	}
+	fmt.Printf("PROXY_URL=%s\n", proxyURL)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+	signal.Stop(sigCh)
+	n, _ := refcount.Release(refcountPath)
+	if n == 0 && isOwner {
+		ln.Close()
+	}
 }
 
 // listenerPort extracts the port from a net.Listener, falling back to the
@@ -336,7 +372,7 @@ func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
 }
 
 // parseArgs separates databricks-codex flags from codex flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, codexArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, headless bool, codexArgs []string) {
 	knownFlags := map[string]bool{
 		"--verbose":         true,
 		"--version":         true,
@@ -353,6 +389,7 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 		"--tls-key":         true,
 		"--model":           true,
 		"--port":            true,
+		"--headless":        true,
 	}
 
 	i := 0
@@ -465,6 +502,8 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 						i++
 						portFlag, _ = strconv.Atoi(args[i])
 					}
+				case "--headless":
+					headless = true
 				}
 				i++
 				continue
@@ -502,6 +541,7 @@ Databricks-Codex Flags:
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Fixed proxy port (default: 49154, saved to state)
+  --headless                Start proxy without launching codex (for IDE extensions)
   --version             Print version and exit
   --help, -h            Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -24,70 +24,70 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -97,7 +97,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTable(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
 	if !otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=true when --otel-logs-table is passed")
 	}
@@ -106,7 +106,7 @@ func TestParseArgs_OtelLogsTable(t *testing.T) {
 	}
 }
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
 	if otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -114,14 +114,14 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
 	if len(codexArgs) != 1 || codexArgs[0] != "--unknown" {
 		t.Errorf("expected codexArgs=[\"--unknown\"], got %v", codexArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, codexArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv || noOtel || otel {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -140,7 +140,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -153,7 +153,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -163,7 +163,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
 	if len(codexArgs) != 3 {
 		t.Errorf("expected 3 codexArgs, got %d: %v", len(codexArgs), codexArgs)
 	}
@@ -172,7 +172,7 @@ func TestParseArgs_PassthroughArgs(t *testing.T) {
 // --- Model flag tests ---
 
 func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model is passed")
 	}
@@ -182,7 +182,7 @@ func TestParseArgs_Model(t *testing.T) {
 }
 
 func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model=custom-model"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _ := parseArgs([]string{"--model=custom-model"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model=value is passed")
 	}
@@ -192,7 +192,7 @@ func TestParseArgs_ModelEquals(t *testing.T) {
 }
 
 func TestParseArgs_ModelDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _ := parseArgs([]string{})
 	if modelSet {
 		t.Error("expected modelSet=false when --model is not passed")
 	}
@@ -202,7 +202,7 @@ func TestParseArgs_ModelDefault(t *testing.T) {
 }
 
 func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
 	if !modelSet {
 		t.Error("expected modelSet=true")
 	}
@@ -229,6 +229,7 @@ func TestParseArgs_Table(t *testing.T) {
 		model    string
 		modelSet bool
 		portFlag int
+		headless bool
 		codexLen int
 	}
 
@@ -342,11 +343,16 @@ func TestParseArgs_Table(t *testing.T) {
 			args: []string{"--port=8080"},
 			want: result{portFlag: 8080},
 		},
+		{
+			name: "--headless sets headless",
+			args: []string{"--headless"},
+			want: result{headless: true},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, portFlag, codexArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, portFlag, headless, codexArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -383,6 +389,9 @@ func TestParseArgs_Table(t *testing.T) {
 			}
 			if portFlag != tc.want.portFlag {
 				t.Errorf("portFlag: got %d, want %d", portFlag, tc.want.portFlag)
+			}
+			if headless != tc.want.headless {
+				t.Errorf("headless: got %v, want %v", headless, tc.want.headless)
 			}
 			if len(codexArgs) != tc.want.codexLen {
 				t.Errorf("codexArgs length: got %d, want %d (args: %v)", len(codexArgs), tc.want.codexLen, codexArgs)
@@ -518,21 +527,28 @@ func TestHandleHelp_ContainsCodexCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
 }
 
+func TestParseArgs_Headless(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _ := parseArgs([]string{"--headless"})
+	if !headless {
+		t.Error("expected headless=true for --headless")
+	}
+}
+
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -542,7 +558,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--version", "--help"}
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)


### PR DESCRIPTION
## Summary

- Adds `--headless` flag that starts the proxy without launching the `codex` child process
- Prints `PROXY_URL=<url>` to stdout, then blocks on SIGINT/SIGTERM for clean shutdown
- Skips `codex` binary LookPath check and treats EnsureConfig errors as warnings in headless mode

Closes #25

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (new `TestParseArgs_Headless` + table-driven case)
- [ ] Manual: `databricks-codex --headless` prints `PROXY_URL=...` and waits for Ctrl-C
- [ ] Manual: verify proxy responds to `/health` while headless
- [ ] Manual: Ctrl-C cleanly shuts down (refcount released, listener closed if last session)