### PR TITLE
fix: use api_key in config.toml so headless mode works without env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ databricks-codex configuration:
   Profile:           DEFAULT
   DATABRICKS_HOST:   https://adb-1234567890123456.7.azuredatabricks.net
   OPENAI_BASE_URL:   https://1234567890123456.ai-gateway.cloud.databricks.com/openai/v1
-  OPENAI_API_KEY:    dapi-***
+  Auth Token:        dapi-***
   OpenTelemetry Logs Table:   main.codex_telemetry.codex_otel_logs
   Codex binary:      /usr/local/bin/codex
 ```
@@ -116,14 +116,14 @@ databricks-codex configuration:
 Notes:
 
 - `OPENAI_BASE_URL` is the resolved upstream Databricks endpoint, not the localhost proxy address
-- `OPENAI_API_KEY` is always redacted in this output
+- `Auth Token` is always redacted in this output
 - `Codex binary` shows `(not found)` if `codex` is not on your `PATH`
 
 If the profile, host, or URL looks wrong, check your Databricks CLI setup with `databricks auth env` and `databricks auth token`.
 
 ## Proxy behavior
 
-`databricks-codex` does not rely solely on exporting `OPENAI_BASE_URL` and `OPENAI_API_KEY` into the shell environment. Instead, it binds a fixed local proxy on `127.0.0.1:49154` and writes `~/.codex/config.toml` once to point Codex at that proxy.
+`databricks-codex` does not rely on exporting environment variables. Instead, it binds a fixed local proxy on `127.0.0.1:49154` and writes `~/.codex/config.toml` once to point Codex at that proxy (including a placeholder `api_key` — the proxy injects the real Databricks token per-request).
 
 This lets the wrapper:
 

--- a/main.go
+++ b/main.go
@@ -262,10 +262,6 @@ func main() {
 		return
 	}
 
-	// Set OPENAI_API_KEY as a placeholder — the proxy overwrites the
-	// Authorization header with a live Databricks token per request.
-	os.Setenv("OPENAI_API_KEY", "databricks-proxy")
-
 	if otel {
 		log.Printf("databricks-codex: OTEL enabled — logs=%s", otelLogsTable)
 	}
@@ -586,7 +582,7 @@ func handlePrintEnv(databricksHost, openaiBaseURL, token, profile, model, otelLo
   Model:             %s
   DATABRICKS_HOST:   %s
   OPENAI_BASE_URL:   %s
-  OPENAI_API_KEY:    %s
+  Auth Token:        %s
   OTEL Logs Table:   %s
   Codex binary:      %s
 `, profile, model, databricksHost, openaiBaseURL, redacted, otelLogsTable, codexPath)

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -168,7 +168,7 @@ func (m *Manager) buildProviderSection(cfg PatchConfig) string {
 	var b strings.Builder
 	b.WriteString("name = \"Databricks Proxy\"\n")
 	b.WriteString(fmt.Sprintf("base_url = %q\n", cfg.ProxyURL))
-	b.WriteString("env_key = \"OPENAI_API_KEY\"\n")
+	b.WriteString("api_key = \"databricks-proxy\"\n")
 	b.WriteString("wire_api = \"responses\"\n")
 	return b.String()
 }

--- a/pkg/tomlconfig/tomlconfig_test.go
+++ b/pkg/tomlconfig/tomlconfig_test.go
@@ -107,7 +107,7 @@ model = "custom-user-model"
 [model_providers.databricks-proxy]
 name = "Databricks Proxy"
 base_url = "http://old-proxy:1234"
-env_key = "OPENAI_API_KEY"
+api_key = "databricks-proxy"
 wire_api = "responses"
 `
 	m, configPath := setup(t, initial)
@@ -138,7 +138,7 @@ model = "custom-user-model"
 [model_providers.databricks-proxy]
 name = "Databricks Proxy"
 base_url = "http://old-proxy:1234"
-env_key = "OPENAI_API_KEY"
+api_key = "databricks-proxy"
 wire_api = "responses"
 `
 	m, configPath := setup(t, initial)
@@ -213,7 +213,7 @@ model = "original-model"
 [model_providers.databricks-proxy]
 name = "Databricks Proxy"
 base_url = "http://old-proxy:1234"
-env_key = "OPENAI_API_KEY"
+api_key = "databricks-proxy"
 wire_api = "responses"
 
 [projects.myapp]

--- a/process.go
+++ b/process.go
@@ -23,9 +23,9 @@ var otelKeys = []string{
 }
 
 // RunCodex starts the codex CLI as a child process with the supplied arguments
-// and waits for it to exit. Environment variables (OPENAI_BASE_URL,
-// OPENAI_API_KEY, OTEL vars) are expected to be set on os.Environ by main.go
-// before calling this function.
+// and waits for it to exit. OTEL environment variables are expected to be set
+// on os.Environ by main.go before calling this function. The API key and base
+// URL are configured via config.toml (not environment variables).
 func RunCodex(ctx context.Context, args []string) (int, error) {
 	return childproc.Run(ctx, childproc.Config{
 		BinaryName: "codex",


### PR DESCRIPTION
Headless mode failed because config.toml used env_key = "OPENAI_API_KEY" (an indirection) but the env var was only set for child-process mode. Write api_key = "databricks-proxy" directly into config.toml instead, making the config self-contained for both headless and normal modes.