### PR TITLE
fix: retrigger homebrew dispatch for v0.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ make build
 ## License
 
 MIT
+


### PR DESCRIPTION
Triggers release-please to cut v0.5.1 so the homebrew-tap dispatch fires.