### PR TITLE
chore: add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ You use it exactly like `codex`. Every flag and argument is forwarded.
 
 ## Installation
 
+### Via Homebrew (recommended)
+
+```bash
+brew tap IceRhymers/tap
+brew install databricks-codex
+```
+
 ### From source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ make build
 ## License
 
 MIT
+


### PR DESCRIPTION
Adds `brew tap IceRhymers/tap && brew install databricks-codex` as the recommended install method.