### PR TITLE
fix: bump databricks-claude to v0.10.1 for completion --shell= support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.10.0
+require github.com/IceRhymers/databricks-claude v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.8.1 h1:1gFFG98yLNWf8cR+aFrHIrrTMFItQ/AvRUaPdcnngVU=
-github.com/IceRhymers/databricks-claude v0.8.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
-github.com/IceRhymers/databricks-claude v0.10.0 h1:WOzOMVXd6Eu/tc2dYo/ORyFvqi8lZtCtrgFHprm37p8=
-github.com/IceRhymers/databricks-claude v0.10.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.10.1 h1:jg7KK6UfjQyGm2wG+byu11UOdtyrlp8oWnrkbgCaLzo=
+github.com/IceRhymers/databricks-claude v0.10.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=


### PR DESCRIPTION
## Summary

Bumps `databricks-claude` dependency from v0.10.0 → v0.10.1.

v0.10.1 fixes `pkg/completion.Run` to accept both positional (`completion bash`) and flag (`completion --shell=bash`) shell arguments. Homebrew's `generate_completions_from_executable` always passes `--shell=bash` regardless of `shell_parameter_format`, causing brew install to fail with:

```
databricks-codex completion: unknown shell "--shell=bash" (supported: bash zsh fish)
```

## Test plan

- [ ] `go test ./...` passes
- [ ] `databricks-codex completion --shell=bash` produces valid output
- [ ] Homebrew tap CI passes after binary release

🤖 Generated with [Claude Code](https://claude.com/claude-code)