### PR TITLE
feat: add update subcommand and startup update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,50 @@ make test
 make build
 ```
 
+## Automatic Update Check
+
+`databricks-codex` checks for newer releases on startup (once every 24 hours) and prints a one-line notice to stderr when an update is available. The check is synchronous with a 2-second timeout — if GitHub is unreachable it silently skips.
+
+### Update notification
+
+When a newer version exists you'll see:
+
+```
+# Direct install
+databricks-codex: update available (v0.8.0). Run: databricks-codex update
+
+# Homebrew install
+databricks-codex: update available (v0.8.0). Run: brew upgrade databricks-codex
+```
+
+### `update` subcommand
+
+```bash
+databricks-codex update
+```
+
+Force-checks GitHub for the latest release (bypasses the 24-hour cache) and prints upgrade instructions:
+
+| Install method | Output |
+|---|---|
+| Already latest | `databricks-codex v0.7.1 is already the latest version` |
+| Direct install | `Update available: v0.8.0. Download from: https://github.com/...` |
+| Homebrew | `Update available: v0.8.0. Run: brew upgrade databricks-codex` |
+
+No binary is replaced — the command prints instructions only. In-place self-update is planned for a future release.
+
+### Opt out
+
+```bash
+# Per-invocation flag
+databricks-codex --no-update-check
+
+# Per-session or permanent (add to shell profile)
+export DATABRICKS_NO_UPDATE_CHECK=1
+```
+
+Both suppress the startup check and disable the `update` subcommand.
+
 ## License
 
 MIT

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -32,6 +32,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "install-hooks", Description: "Install SessionStart hook into ~/.codex/hooks.json"},
 	{Name: "uninstall-hooks", Description: "Remove databricks-codex hooks from ~/.codex/hooks.json"},
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
+	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-codex

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.10.1
+require github.com/IceRhymers/databricks-claude v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.10.1 h1:jg7KK6UfjQyGm2wG+byu11UOdtyrlp8oWnrkbgCaLzo=
-github.com/IceRhymers/databricks-claude v0.10.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.11.0 h1:VjR+gSPYDINk7DJEI4kR9UP6mRIoyzPoB1wsy7DJBn4=
+github.com/IceRhymers/databricks-claude v0.11.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+	"github.com/IceRhymers/databricks-claude/pkg/updater"
 )
 
 // Version is set at build time via -ldflags.
@@ -38,7 +39,34 @@ func main() {
 		os.Exit(0)
 	}
 
-	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, codexArgs := parseArgs(os.Args[1:])
+	// update — force-check for a newer release and print instructions.
+	if len(os.Args) >= 2 && os.Args[1] == "update" {
+		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
+			fmt.Fprintln(os.Stderr, "databricks-codex: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
+			os.Exit(0)
+		}
+		cfg := buildUpdaterConfig()
+		cfg.CacheTTL = 0 // force fresh check
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		r, err := updater.Check(ctx, cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-codex: update check failed: %v\n", err)
+			os.Exit(1)
+		}
+		if !r.UpdateAvailable {
+			fmt.Fprintf(os.Stderr, "databricks-codex v%s is already the latest version\n", Version)
+			os.Exit(0)
+		}
+		if r.IsHomebrew {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-codex\n", r.LatestVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
+		}
+		os.Exit(0)
+	}
+
+	verbose, version, showHelp, printEnv, noOtel, otelLogsTable, otelLogsTableSet, upstream, logFile, profile, otel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, noUpdateCheck, codexArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -318,6 +346,11 @@ func main() {
 		log.Printf("databricks-codex: OTEL enabled — logs=%s", otelLogsTable)
 	}
 
+	// --- Synchronous update check (before child to avoid stderr interleaving) ---
+	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
+		printUpdateNotice(buildUpdaterConfig())
+	}
+
 	log.Printf("databricks-codex: launching codex")
 
 	// --- Run codex as a child process (parent stays alive to serve the proxy) ---
@@ -505,7 +538,7 @@ func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
 }
 
 // parseArgs separates databricks-codex flags from codex flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, codexArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, noOtel bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, profile string, otel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, noUpdateCheck bool, codexArgs []string) {
 	idleTimeout = 30 * time.Minute // default
 
 	// knownFlags is defined at package level in completion_flags.go,
@@ -643,6 +676,8 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 					uninstallHooksFlag = true
 				case "--headless-ensure":
 					headlessEnsureFlag = true
+				case "--no-update-check":
+					noUpdateCheck = true
 				}
 				i++
 				continue
@@ -685,8 +720,13 @@ Databricks-Codex Flags:
   --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables, bare number = minutes)
   --install-hooks           Install SessionStart hook into ~/.codex/hooks.json
   --uninstall-hooks         Remove databricks-codex hooks from ~/.codex/hooks.json
+  --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
+
+Subcommands:
+  completion <shell>           Generate shell completions (bash, zsh, fish)
+  update                       Check for a newer release and print upgrade instructions
 
 ────────────────────────────────────────────────────────────────────────────────
 Codex CLI Options:
@@ -710,6 +750,38 @@ Codex CLI Options:
 	cmd.Stderr = &buf
 	_ = cmd.Run()
 	fmt.Print(buf.String())
+}
+
+// buildUpdaterConfig returns the standard updater.Config for databricks-codex.
+func buildUpdaterConfig() updater.Config {
+	home, _ := os.UserHomeDir()
+	return updater.Config{
+		RepoSlug:       "IceRhymers/databricks-codex",
+		CurrentVersion: Version,
+		BinaryName:     "databricks-codex",
+		CacheFile:      filepath.Join(home, ".codex", ".update-check.json"),
+		CacheTTL:       24 * time.Hour,
+	}
+}
+
+// printUpdateNotice checks for a newer release and prints a one-line notice
+// to stderr. The 2-second timeout ensures cold misses don't delay startup.
+func printUpdateNotice(cfg updater.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r, err := updater.Check(ctx, cfg)
+	if err != nil {
+		log.Printf("databricks-codex: update check: %v", err)
+		return
+	}
+	if !r.UpdateAvailable {
+		return
+	}
+	if r.IsHomebrew {
+		fmt.Fprintf(os.Stderr, "databricks-codex: update available (v%s). Run: brew upgrade databricks-codex\n", r.LatestVersion)
+	} else {
+		fmt.Fprintf(os.Stderr, "databricks-codex: update available (v%s). Run: databricks-codex update\n", r.LatestVersion)
+	}
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -24,70 +24,70 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -97,7 +97,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTable(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.custom.logs"})
 	if !otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=true when --otel-logs-table is passed")
 	}
@@ -106,7 +106,7 @@ func TestParseArgs_OtelLogsTable(t *testing.T) {
 	}
 }
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, otelLogsTable, otelLogsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{})
 	if otelLogsTableSet {
 		t.Error("expected otelLogsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -114,14 +114,14 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--unknown"})
 	if len(codexArgs) != 1 || codexArgs[0] != "--unknown" {
 		t.Errorf("expected codexArgs=[\"--unknown\"], got %v", codexArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv || noOtel || otel {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -140,7 +140,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -153,7 +153,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -163,7 +163,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"prompt text", "--unknown-flag", "gpt-4"})
 	if len(codexArgs) != 3 {
 		t.Errorf("expected 3 codexArgs, got %d: %v", len(codexArgs), codexArgs)
 	}
@@ -172,7 +172,7 @@ func TestParseArgs_PassthroughArgs(t *testing.T) {
 // --- Model flag tests ---
 
 func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "databricks-gpt-5-4-mini"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model is passed")
 	}
@@ -182,7 +182,7 @@ func TestParseArgs_Model(t *testing.T) {
 }
 
 func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _ := parseArgs([]string{"--model=custom-model"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model=custom-model"})
 	if !modelSet {
 		t.Error("expected modelSet=true when --model=value is passed")
 	}
@@ -192,7 +192,7 @@ func TestParseArgs_ModelEquals(t *testing.T) {
 }
 
 func TestParseArgs_ModelDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _, _ := parseArgs([]string{})
 	if modelSet {
 		t.Error("expected modelSet=false when --model is not passed")
 	}
@@ -202,7 +202,7 @@ func TestParseArgs_ModelDefault(t *testing.T) {
 }
 
 func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _, _, _, _, _, _, codexArgs := parseArgs([]string{"--model", "my-model", "prompt"})
 	if !modelSet {
 		t.Error("expected modelSet=true")
 	}
@@ -370,7 +370,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, portFlag, headless, _, installHooks, uninstallHooks, headlessEnsure, codexArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, noOtel, _, _, upstream, logFile, profile, otel, _, _, _, model, modelSet, portFlag, headless, _, installHooks, uninstallHooks, headlessEnsure, _, codexArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -554,28 +554,35 @@ func TestHandleHelp_ContainsCodexCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _ := parseArgs([]string{"--headless"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _ := parseArgs([]string{"--headless"})
 	if !headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
+func TestParseArgs_NoUpdateCheck(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noUpdateCheck, _ := parseArgs([]string{"--no-update-check"})
+	if !noUpdateCheck {
+		t.Error("expected noUpdateCheck=true for --no-update-check")
+	}
+}
+
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -585,7 +592,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--headless-ensure", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--version", "--help"}
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--headless-ensure", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--no-update-check", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)


### PR DESCRIPTION
## Summary

Wires `pkg/updater` from databricks-claude v0.11.0 into databricks-codex:

- `databricks-codex update` subcommand — force-checks GitHub for newer release (CacheTTL=0, 10s timeout) and prints upgrade instructions (Homebrew or direct download)
- Synchronous startup check before child launch (2s timeout, 24h cache). Cache hits are sub-ms; cold misses that exceed 2s are silently skipped.
- `--no-update-check` flag and `DATABRICKS_NO_UPDATE_CHECK=1` env var to opt out
- `buildUpdaterConfig` / `printUpdateNotice` helpers with cache at `~/.codex/.update-check.json`
- Help text updated with Subcommands section
- README section documenting update check behavior and opt-out

## Test plan

- All existing tests updated for new `noUpdateCheck` return value from `parseArgs`
- New `TestParseArgs_NoUpdateCheck` test added
- `go build ./...`, `go test ./...` all pass

Closes #49