### PR TITLE
chore: dispatch Scoop manifest update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,18 @@ jobs:
             -f "client_payload[tool]=databricks-codex" \
             -f "client_payload[tag]=${{ needs.release-please.outputs.tag_name }}" \
             -f "client_payload[version]=${{ needs.release-please.outputs.tag_name }}"
+  update-scoop:
+    needs: [release-please, build-and-upload]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch manifest update to scoop-bucket
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          VERSION="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${VERSION#v}"
+          gh api repos/IceRhymers/scoop-bucket/dispatches \
+            -f event_type=update-databricks-codex \
+            -f "client_payload[binary]=databricks-codex" \
+            -f "client_payload[version]=${VERSION}"


### PR DESCRIPTION
Adds an `update-scoop` job to release.yml that fires a `repository_dispatch` event to [IceRhymers/scoop-bucket](https://github.com/IceRhymers/scoop-bucket) after each release, keeping the Windows Scoop manifest in sync automatically.