### PR TITLE
feat: add update subcommand and startup update check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.11.0
+require github.com/IceRhymers/databricks-claude v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.11.0 h1:VjR+gSPYDINk7DJEI4kR9UP6mRIoyzPoB1wsy7DJBn4=
-github.com/IceRhymers/databricks-claude v0.11.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.12.0 h1:kKQqKNj0N8F4bmujfI504LKzvaa6VZvd2kLmB27xWUI=
+github.com/IceRhymers/databricks-claude v0.12.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=


### PR DESCRIPTION
## Summary

- Bumps `databricks-claude` dependency from v0.11.0 to v0.12.0 to resolve `pkg/updater`
- The `update` subcommand, startup update check, `--no-update-check` flag, `DATABRICKS_NO_UPDATE_CHECK` env var, help text, and completions were already implemented in main.go — this PR unblocks them by providing the dependency

Closes #53

## Test plan

- `go build ./...` passes
- `go test ./...` passes (all tests green)
- `go vet ./...` passes
- `databricks-codex update` prints upgrade instructions or "already the latest version"
- `databricks-codex --no-update-check` suppresses startup check
- `DATABRICKS_NO_UPDATE_CHECK=1 databricks-codex update` prints disabled message