### PR TITLE
docs: add Windows installation section (Scoop + direct binary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ brew tap IceRhymers/tap
 brew install databricks-codex
 ```
 
+### Via Scoop (Windows)
+
+```powershell
+scoop bucket add icerhymers https://github.com/IceRhymers/scoop-bucket
+scoop install databricks-codex
+```
+
+### Direct binary (Windows)
+
+Download the latest release from the [releases page](https://github.com/IceRhymers/databricks-codex/releases), pick `databricks-codex-windows-amd64.exe` (or `arm64`), rename it to `databricks-codex.exe`, and place it somewhere on your `PATH`.
+
 ### From source
 
 ```bash


### PR DESCRIPTION
Adds a Windows installation section to the README with two methods:
- Via Scoop: `scoop bucket add icerhymers https://github.com/IceRhymers/scoop-bucket && scoop install databricks-codex`
- Direct binary download from the releases page