### PR TITLE
docs: add release-please conventional commit convention to AGENTS.md

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- Parent: ../AGENTS.md -->
+
+# workflows
+
+## Purpose
+GitHub Actions CI pipeline. Runs on pushes and pull requests to `master`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `ci.yml` | CI job: checkout, setup Go, run `go test ./... -v`, `go vet ./...`, and `go build` |
+| `release.yml` | release-please workflow: opens release PRs and publishes GitHub Releases on merge to `master` |
+
+## For AI Agents
+
+### Working In This Directory
+- The CI job runs on `ubuntu-latest`.
+- Go version is read from `go.mod`.
+- If adding new CI steps, keep them in the single `ci` job unless parallelism is needed.
+
+### Testing Requirements
+- CI must pass: `go test ./... -v`, `go vet ./...`, and `go build`.
+
+## Release Process (release-please)
+
+Releases are automated via [release-please](https://github.com/googleapis/release-please). It watches commits merged to `master` and opens a release PR automatically — **but only when commits follow the Conventional Commits format**.
+
+### Commit prefix rules
+
+| Prefix | Version bump | When to use |
+|--------|-------------|-------------|
+| `feat:` | minor (0.X.0) | New user-facing feature or behaviour change |
+| `fix:` | patch (0.0.X) | Bug fix |
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` | major (X.0.0) | Breaking API or behaviour change |
+| `chore:`, `docs:`, `refactor:`, `test:` | none | Internal — **will NOT trigger a release PR** |
+
+### Rules for AI agents
+
+- **Every PR that changes user-facing behaviour must include at least one `feat:` or `fix:` commit.** Without it, release-please skips the run and no release PR is opened.
+- Squash-merge is fine — the squash commit message is what release-please reads.
+- `chore:` is safe for housekeeping (formatting, test updates, doc-only changes) but will not produce a release.
+- If a release PR is unexpectedly missing after a merge, check the release workflow logs: the most common cause is a non-conventional commit message.


### PR DESCRIPTION
## Summary

Creates `.github/workflows/AGENTS.md` with a **Release Process** section documenting which commit prefixes trigger a release-please PR and which do not — matching the same documentation already present in the sibling repos `databricks-claude` and `databricks-opencode`.

Closes #63

## What was added

`.github/workflows/AGENTS.md` — new file covering:
- Overview of `ci.yml` and `release.yml` workflow files
- **Commit prefix rules table**: `feat:` (minor), `fix:` (patch), `feat!:`/`BREAKING CHANGE:` (major), `chore:`/`docs:`/`refactor:`/`test:` (no release)
- **Rules for AI agents**: every user-facing PR needs at least one `feat:` or `fix:` commit; squash-merge is fine; `chore:` won't open a release PR

No code changes — docs only.

## Test plan

- [ ] Review the rendered Markdown in the Files tab
- [ ] Confirm the table and agent rules match the equivalent section in `IceRhymers/databricks-claude/.github/workflows/AGENTS.md`

🦀 *(via claw)*