### PR TITLE
Simplify ConstructGatewayURL: drop SCIM call, use host-relative AI Gateway path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Go 1.22, single external module: `github.com/IceRhymers/databricks-claude` (the 
 ### Main Package Files
 
 - **main.go** — CLI entry point: flag parsing (`parseArgs`), profile/otel-logs-table resolution chains, proxy startup, config.toml patching, codex child process lifecycle.
-- **token.go** — `databricksFetcher` implements `tokencache.TokenFetcher` by shelling out to `databricks auth token`. Also `DiscoverHost` (via `databricks auth env`) and `ConstructGatewayURL` (via SCIM `/Me` for workspace ID).
+- **token.go** — `databricksFetcher` implements `tokencache.TokenFetcher` by shelling out to `databricks auth token`. Also `DiscoverHost` (via `databricks auth env`) and `ConstructGatewayURL` (returns `{host}/ai-gateway/openai/v1`, no network call).
 - **config.go** — `ConfigManager` coordinates tomlconfig, filelock, and session registry. `Setup()` backs up + patches config.toml; `Restore()` handles multi-session handoff or full restore.
 - **state.go** — `persistentState` JSON file at `~/.codex/.databricks-codex.json` for profile and otel-logs-table persistence across sessions.
 - **process.go** — Thin shim: `RunCodex` delegates to `childproc.Run`. Declares `otelKeys` for OTEL env var injection.
@@ -56,7 +56,7 @@ Go 1.22, single external module: `github.com/IceRhymers/databricks-claude` (the 
 - **Proxy-based architecture** — Local HTTP proxy on `127.0.0.1:0` injects fresh Bearer tokens. Codex connects via patched `config.toml` with `wire_api = "responses"` for WebSocket support.
 - **Multi-session coordination** — Session registry tracks live PIDs in `~/.codex/.sessions.json`. Last session restores original config; earlier sessions hand off to the most recent survivor.
 - **Resolution chains** — Profile: `--profile` flag > `DATABRICKS_CONFIG_PROFILE` env > saved state > `"DEFAULT"`. OTEL logs table: `--otel-logs-table` flag > saved state > default. Explicit flag values are persisted for future sessions.
-- **Gateway URL** — `https://<workspaceId>.ai-gateway.cloud.databricks.com/openai/v1`. Falls back to `<host>/serving-endpoints/codex/openai/v1` if workspace ID resolution fails.
+- **Gateway URL** — `{host}/ai-gateway/openai/v1` (no fallback — `ConstructGatewayURL` no longer makes a network call).
 - **WebSocket proxy** — Codex v0.118.0+ uses WebSocket for the Responses API. The proxy (in databricks-claude's `pkg/proxy`) detects `Upgrade: websocket` headers and uses HTTP hijacking.
 
 ## Testing Patterns

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ Databricks AI Gateway uses short-lived OAuth tokens. Without this tool, you'd ne
 
 1. Fetches a fresh Databricks OAuth token via `databricks auth token`
 2. Discovers your workspace host from `databricks auth env`
-3. Resolves your workspace ID via the SCIM API
-4. Constructs the Databricks AI Gateway URL
-5. Binds a local proxy on `127.0.0.1:49154` (fixed port — shared across concurrent sessions) that forwards traffic upstream and refreshes the Databricks token automatically
-6. Writes `~/.codex/config.toml` once to point at the proxy (idempotent — no restore on exit)
-7. Exec's `codex` with your args — fully transparent
+3. Constructs the Databricks AI Gateway URL (`{host}/ai-gateway/openai/v1`)
+4. Binds a local proxy on `127.0.0.1:49154` (fixed port — shared across concurrent sessions) that forwards traffic upstream and refreshes the Databricks token automatically
+5. Writes `~/.codex/config.toml` once to point at the proxy (idempotent — no restore on exit)
+6. Exec's `codex` with your args — fully transparent
 
 You use it exactly like `codex`. Every flag and argument is forwarded.
 
@@ -78,7 +77,7 @@ databricks-codex --log-file /tmp/dc.log "fix the bug in main.go"
 databricks-codex -v --log-file /tmp/dc.log "fix the bug in main.go"
 
 # Override upstream URL for the local proxy:
-databricks-codex --upstream https://1234567890123456.ai-gateway.cloud.databricks.com/openai/v1 "summarize this PR"
+databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway/openai/v1 "summarize this PR"
 ```
 
 ## Flags
@@ -112,10 +111,7 @@ All other flags and args are forwarded to `codex`.
 On startup, `databricks-codex` auto-discovers:
 
 - Your workspace host from `databricks auth env`
-- Your workspace ID via the SCIM API (`x-databricks-org-id` header)
-- Constructs the AI Gateway URL: `https://<workspaceId>.ai-gateway.cloud.databricks.com/openai/v1`
-
-If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/codex/openai/v1`.
+- Constructs the AI Gateway URL: `{host}/ai-gateway/openai/v1`
 
 ## Debugging
 
@@ -133,7 +129,7 @@ Example output:
 databricks-codex configuration:
   Profile:           DEFAULT
   DATABRICKS_HOST:   https://adb-1234567890123456.7.azuredatabricks.net
-  OPENAI_BASE_URL:   https://1234567890123456.ai-gateway.cloud.databricks.com/openai/v1
+  OPENAI_BASE_URL:   https://adb-1234567890123456.7.azuredatabricks.net/ai-gateway/openai/v1
   Auth Token:        dapi-***
   OpenTelemetry Logs Table:   main.codex_telemetry.codex_otel_logs
   Codex binary:      /usr/local/bin/codex

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func main() {
 
 	gatewayURL := upstream
 	if gatewayURL == "" {
-		gatewayURL = ConstructGatewayURL(host, initialToken)
+		gatewayURL = ConstructGatewayURL(host)
 	}
 	log.Printf("databricks-codex: gateway URL: %s", gatewayURL)
 

--- a/token.go
+++ b/token.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/tokencache"
@@ -123,43 +122,8 @@ func DiscoverHost(cmdName, profile string) (string, error) {
 	return host, nil
 }
 
-// ResolveWorkspaceID calls the SCIM /Me endpoint and extracts x-databricks-org-id from response headers.
-func ResolveWorkspaceID(host, token string) (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-
-	req, err := http.NewRequest(http.MethodGet, host+"/api/2.0/preview/scim/v2/Me", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to build SCIM request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("SCIM request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("SCIM request returned status %d", resp.StatusCode)
-	}
-
-	orgID := resp.Header.Get("x-databricks-org-id")
-	if orgID == "" {
-		return "", fmt.Errorf("x-databricks-org-id header not present in SCIM response")
-	}
-	return orgID, nil
-}
-
 // ConstructGatewayURL builds the AI Gateway URL for the Codex proxy endpoint.
-// Format: https://{workspaceId}.ai-gateway.cloud.databricks.com/openai/v1
-// Fallback: {host}/serving-endpoints/codex/openai/v1
-func ConstructGatewayURL(host, token string) string {
-	workspaceID, err := ResolveWorkspaceID(host, token)
-	if err != nil {
-		log.Printf("workspace ID resolution failed: %v", err)
-		return host + "/serving-endpoints/codex/openai/v1"
-	}
-	gatewayURL := "https://" + workspaceID + ".ai-gateway.cloud.databricks.com/openai/v1"
-	log.Printf("resolved workspace ID %s, using gateway URL: %s", workspaceID, gatewayURL)
-	return gatewayURL
+// Format: {host}/ai-gateway/openai/v1
+func ConstructGatewayURL(host string) string {
+	return strings.TrimRight(host, "/") + "/ai-gateway/openai/v1"
 }

--- a/token_test.go
+++ b/token_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -287,74 +285,36 @@ func TestDiscoverHost_CommandFails(t *testing.T) {
 	}
 }
 
-// TestResolveWorkspaceID_Success: mock server returns org-id header -> extracted.
-func TestResolveWorkspaceID_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "1234567890")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	orgID, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestConstructGatewayURL: verifies the host-relative AI Gateway URL format.
+func TestConstructGatewayURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "plain host",
+			host: "https://dbc-abc123.cloud.databricks.com",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "host with trailing slash is trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com/",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "host with multiple trailing slashes is trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com///",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
 	}
-	if orgID != "1234567890" {
-		t.Errorf("got %q, want %q", orgID, "1234567890")
-	}
-}
 
-// TestResolveWorkspaceID_MissingHeader: server returns 200 but no org-id header -> error.
-func TestResolveWorkspaceID_MissingHeader(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err == nil {
-		t.Fatal("expected error when org-id header missing, got nil")
-	}
-}
-
-// TestResolveWorkspaceID_Non200: server returns 401 -> error.
-func TestResolveWorkspaceID_Non200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "bad-token")
-	if err == nil {
-		t.Fatal("expected error on non-200 status, got nil")
-	}
-}
-
-// TestConstructGatewayURL_WithWorkspaceID: resolves workspace ID -> uses AI Gateway domain.
-func TestConstructGatewayURL_WithWorkspaceID(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "9876543210")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "test-token")
-	want := "https://9876543210.ai-gateway.cloud.databricks.com/openai/v1"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// TestConstructGatewayURL_Fallback: resolution fails -> falls back to generic codex endpoint.
-func TestConstructGatewayURL_Fallback(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "bad-token")
-	want := srv.URL + "/serving-endpoints/codex/openai/v1"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConstructGatewayURL(tc.host)
+			if got != tc.want {
+				t.Errorf("ConstructGatewayURL(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #65

## Changes

- **`token.go`** — delete `ResolveWorkspaceID` (SCIM `/Me` call). Rewrite `ConstructGatewayURL(host string) string` to return `{host}/ai-gateway/openai/v1` with trailing slashes trimmed. Drop now-unused `net/http` and `log` imports; add `strings`.
- **`main.go`** — drop the `initialToken` argument from the `ConstructGatewayURL` call site (`initialToken` is still seeded into the token cache as before).
- **`token_test.go`** — remove `TestResolveWorkspaceID_*`, `TestConstructGatewayURL_WithWorkspaceID`, and `TestConstructGatewayURL_Fallback`. Add a table-driven `TestConstructGatewayURL` covering plain host and trailing-slash trimming. Drop now-unused `net/http` and `net/http/httptest` imports.

## Why

The AI Gateway URL format no longer requires a workspace ID — the new `{host}/ai-gateway/{provider}` form is supported directly. This removes a startup network call and matches the pattern adopted in the sister repo (databricks-claude PR #116).