### PR TITLE
chore: bump databricks-claude to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.12.1
+require github.com/IceRhymers/databricks-claude v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.12.1 h1:tnJwn84sxvSm489tQ2TvU7XXSPz4Lk7F2zCaqy2l5hM=
-github.com/IceRhymers/databricks-claude v0.12.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.17.0 h1:YPJgXMLBMmmr3uhgZWLTPbsikTnYOOpRdiDTWakzoQo=
+github.com/IceRhymers/databricks-claude v0.17.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=

--- a/hooks.go
+++ b/hooks.go
@@ -17,13 +17,13 @@ import (
 //
 // The proxy shuts itself down via idle timeout — there is no corresponding
 // release hook because Codex CLI has no session-end event.
-func headlessEnsure(port int) {
+func headlessEnsure(port int) error {
 	s := loadState()
 	scheme := "http"
 	if s.TLSCert != "" {
 		scheme = "https"
 	}
-	headless.Ensure(headless.Config{
+	return headless.Ensure(headless.Config{
 		Port:          port,
 		Scheme:        scheme,
 		TLSCert:       s.TLSCert,

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 	log.Printf("databricks-codex: using model: %s", model)
 
 	// --- Ensure the user is authenticated before proceeding ---
-	if err := authcheck.EnsureAuthenticated(profile, "codex"); err != nil {
+	if err := authcheck.EnsureAuthenticated(profile, ""); err != nil {
 		log.Fatalf("databricks-codex: auth failed: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -101,7 +101,9 @@ func main() {
 	if headlessEnsureFlag {
 		state := loadState()
 		port := resolvePort(portFlag, state)
-		headlessEnsure(port)
+		if err := headlessEnsure(port); err != nil {
+			log.Fatalf("databricks-codex: headless ensure failed: %v", err)
+		}
 		os.Exit(0)
 	}
 
@@ -168,7 +170,7 @@ func main() {
 	log.Printf("databricks-codex: using model: %s", model)
 
 	// --- Ensure the user is authenticated before proceeding ---
-	if err := authcheck.EnsureAuthenticated(profile); err != nil {
+	if err := authcheck.EnsureAuthenticated(profile, "codex"); err != nil {
 		log.Fatalf("databricks-codex: auth failed: %v", err)
 	}
 
@@ -284,7 +286,7 @@ func main() {
 	if proxyAPIKey != "" {
 		fmt.Fprintln(os.Stderr, "databricks-codex: proxy API key authentication enabled")
 	}
-	proxyHandler := NewProxyServer(&ProxyConfig{
+	proxyHandler, err := NewProxyServer(&ProxyConfig{
 		InferenceUpstream: gatewayURL,
 		OTELUpstream:      otelUpstream,
 		UCLogsTable:       otelLogsTable,
@@ -296,6 +298,9 @@ func main() {
 		ToolName:          "databricks-codex",
 		Version:           Version,
 	})
+	if err != nil {
+		log.Fatalf("databricks-codex: failed to create proxy: %v", err)
+	}
 
 	// --- Reference counting ---
 	// In wrapper mode, the parent process acquires here and releases on exit.
@@ -335,7 +340,7 @@ func main() {
 	} else {
 		log.Printf("databricks-codex: joining existing proxy on :%d", port)
 		// Watch for owner death and take over the proxy if needed.
-		go health.WatchProxy(port, proxyHandler, tlsCert, tlsKey, "databricks-codex")
+		go health.WatchProxy(port, proxyHandler, tlsCert, tlsKey, "databricks-codex", nil)
 	}
 	log.Printf("databricks-codex: proxy on %s (owner=%v)", proxyURL, isOwner)
 

--- a/proxy.go
+++ b/proxy.go
@@ -24,7 +24,7 @@ type ProxyConfig struct {
 
 // NewProxyServer returns an http.Handler that routes requests to the
 // inference upstream (default) and the OTEL upstream (/otel/).
-func NewProxyServer(config *ProxyConfig) http.Handler {
+func NewProxyServer(config *ProxyConfig) (http.Handler, error) {
 	return proxy.NewServer(&proxy.Config{
 		InferenceUpstream: config.InferenceUpstream,
 		OTELUpstream:      config.OTELUpstream,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -35,7 +35,10 @@ func TestProxy_InjectsAuthHeader(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("test-token-123"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
@@ -68,7 +71,10 @@ func TestProxy_RoutesDefaultToInference(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
@@ -100,7 +106,10 @@ func TestProxy_RoutesOTELPath(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -128,7 +137,10 @@ func TestProxy_OTELTableName_Logs(t *testing.T) {
 		UCLogsTable:       "main.telemetry.codex_otel_logs",
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/logs", nil)
 	rec := httptest.NewRecorder()
@@ -156,7 +168,10 @@ func TestProxy_PreservesRequestBody(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -193,7 +208,10 @@ func TestProxy_SSEStreaming(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	l, err := StartProxy(handler, "", "")
 	if err != nil {


### PR DESCRIPTION
Bumps `github.com/IceRhymers/databricks-claude` from **v0.12.1 → v0.17.0**.

## Inherited upstream fixes (v0.13–v0.17)

- **Sanitize patterns** — additional token formats now redacted from logs.
- **Empty Bearer guard** — no more empty `Authorization: Bearer` sent upstream when token fetch fails.
- **WebSocket goroutine leak fix** — dropped clients no longer leak goroutines.
- **Lifecycle takeover wiring** — health-watcher takeover re-wraps lifecycle, preserving cancellation/cleanup.
- **Library `log.Fatalf` removed** — `pkg/proxy.NewServer` and `pkg/headless.Ensure` now return errors instead of fatally exiting from library code.
- **Stale `127.0.0.1:<port>` entry cleanup** in registry.
- **Atomic `os.CreateTemp`** for concurrent settings writes.
- **authcheck CLI fallback** — `EnsureAuthenticated` resolves the `databricks` CLI via `pkg/cli.ResolveDatabricksCLI`, fixing GUI-launch false-negatives.

## Call-site fixes

- `proxy.go::NewProxyServer` — propagate the new `(http.Handler, error)` return.
- `main.go` — handle `NewProxyServer` error; pass `cmdName` to `authcheck.EnsureAuthenticated`; pass `onTakeover` (nil) to `health.WatchProxy`.
- `hooks.go::headlessEnsure` — return `error` instead of swallowing it; `main.go` SessionStart path `log.Fatalf`s on failure.
- `proxy_test.go` — updated all six `NewProxyServer` call sites.

## Verification

- `go build ./...` ✅
- `make test` ✅ (all packages pass)
- `make lint` (`go vet ./...`) ✅

Closes #69