### PR TITLE
fix: atomic file writes in hooks.go

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -160,13 +160,55 @@ func writeHooksDoc(path string, doc map[string]interface{}) error {
 		return fmt.Errorf("marshalling hooks: %w", err)
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o600)
+	return atomicWriteFile(path, data, 0o600)
+}
+
+// atomicWriteFile writes data to a temp file in the same directory as path,
+// then renames it into place. This prevents partial-write
+// corruption from concurrent invocations or crashes mid-write. The temp file
+// is created in the destination directory so the rename is atomic on the same
+// filesystem.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".hooks-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // ensureHooksFeatureFlag ensures config.toml contains codex_hooks = true
 // inside a [features] section. Surgical: if the key already exists it's a
 // no-op; if [features] exists the key is appended inside it; otherwise a
 // new section is appended at the end.
+//
+// TODO(#72 follow-up): This writes directly to the same config.toml that
+// tomlconfig.Manager owns, bypassing the manager's backup/restore bookkeeping.
+// There is a TOCTOU window if a session is patching config.toml concurrently.
+// Routing this through tomlconfig.Manager is out of scope for the atomic-write
+// fix and tracked as a separate follow-up.
 func ensureHooksFeatureFlag(configPath string) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -203,5 +245,5 @@ func ensureHooksFeatureFlag(configPath string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
-	return os.WriteFile(configPath, []byte(content), 0o600)
+	return atomicWriteFile(configPath, []byte(content), 0o600)
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -152,6 +152,115 @@ func TestUninstallHooks_NoFile(t *testing.T) {
 	}
 }
 
+// TestAtomicWriteFile_NoTmpDebris verifies the helper leaves no temp file
+// behind after a successful write.
+func TestAtomicWriteFile_NoTmpDebris(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "hooks.json")
+
+	if err := atomicWriteFile(dest, []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover file in dir: %s", name)
+	}
+
+	// Permissions preserved.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected 0o600 perms, got %v", info.Mode().Perm())
+	}
+}
+
+// TestAtomicWriteFile_PreservesOriginalOnRenameFailure verifies that if the
+// rename fails (simulated by making the destination a directory), the
+// original file at the destination path is untouched and no temp debris
+// is left behind.
+func TestAtomicWriteFile_PreservesOriginalOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory at the destination path — os.Rename of a regular
+	// file onto an existing non-empty directory fails on Linux, simulating
+	// a write failure mid-operation.
+	dest := filepath.Join(dir, "hooks.json")
+	if err := os.Mkdir(dest, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Put a file inside so the dir is non-empty (rename will fail).
+	if err := os.WriteFile(filepath.Join(dest, "marker"), []byte("orig"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := atomicWriteFile(dest, []byte("new content"), 0o600)
+	if err == nil {
+		t.Fatal("expected atomicWriteFile to fail when dest is a non-empty dir")
+	}
+
+	// The directory and its contents must still be intact.
+	got, err := os.ReadFile(filepath.Join(dest, "marker"))
+	if err != nil {
+		t.Fatalf("original marker missing after failed write: %v", err)
+	}
+	if string(got) != "orig" {
+		t.Errorf("original content corrupted: got %q", got)
+	}
+
+	// No .tmp debris left in dir.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover file: %s", e.Name())
+	}
+}
+
+// TestWriteHooksDoc_AtomicReplace verifies writeHooksDoc replaces an existing
+// file without leaving temp debris and preserves the new content.
+func TestWriteHooksDoc_AtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	// Seed with original content.
+	if err := writeHooksDoc(hooksPath, map[string]interface{}{"v": float64(1)}); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	// Overwrite.
+	if err := writeHooksDoc(hooksPath, map[string]interface{}{"v": float64(2)}); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if doc["v"].(float64) != 2 {
+		t.Errorf("expected v=2 after atomic replace, got %v", doc["v"])
+	}
+
+	// No .tmp debris.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover: %s", e.Name())
+	}
+}
+
 // TestIsDBXHookEntry verifies detection of databricks-codex hook entries.
 func TestIsDBXHookEntry(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Replaces non-atomic os.WriteFile with temp-file-then-rename in writeHooksDoc and ensureHooksFeatureFlag.

Mirrors databricks-claude PR #135 (a2d97a0).

- New `atomicWriteFile` private helper in hooks.go (temp file in same dir, chmod, write, close, rename).
- Tests: `TestAtomicWriteFile_NoTmpDebris`, `TestAtomicWriteFile_PreservesOriginalOnFailure`, `TestWriteHooksDoc_AtomicReplace`.
- Added TODO comment on `ensureHooksFeatureFlag` noting the TOCTOU window with tomlconfig.Manager (out of scope for this fix; tracked as follow-up).

Closes #72