### PR TITLE
feat: default model is now databricks-gpt-5-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 | `--no-otel-metrics` | | Disable metrics for this session (saved table preserved) |
 | `--no-otel-logs` | | Disable logs for this session (saved table preserved) |
 | `--profile` | saved/`DEFAULT` | Databricks CLI profile (saved to state file; `--profile` flag writes it once) |
-| `--model` | `databricks-gpt-5-4` | Model to use (saved for future sessions) |
+| `--model` | `databricks-gpt-5-5` | Model to use (saved for future sessions) |
 | `--port` | `49154` | Proxy listen port (saved for future sessions) |
 | `--upstream` | auto-discovered | Override the upstream inference URL the local proxy forwards to |
 | `--proxy-api-key` | disabled | Require this API key on all local proxy requests |

--- a/main.go
+++ b/main.go
@@ -147,20 +147,17 @@ func main() {
 
 	// --- Resolve model ---
 	modelExplicit := a.ModelSet
-	model := a.Model
-	if model == "" {
-		if saved := loadState(); saved.Model != "" {
-			model = saved.Model
-			log.Printf("databricks-codex: using saved model: %s", model)
-		}
-	}
-	if model == "" {
-		model = defaultModel()
+	savedForModel := loadState()
+	model := resolveModel(a.Model, savedForModel.Model)
+	switch {
+	case a.Model != "":
+		// flag-supplied; logged below
+	case savedForModel.Model != "":
+		log.Printf("databricks-codex: using saved model: %s", savedForModel.Model)
 	}
 	if modelExplicit {
-		saved := loadState()
-		saved.Model = model
-		if err := saveState(saved); err != nil {
+		savedForModel.Model = model
+		if err := saveState(savedForModel); err != nil {
 			log.Printf("databricks-codex: failed to save model: %v", err)
 		} else {
 			log.Printf("databricks-codex: saved model %q for future sessions", model)

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 		}
 	}
 	if model == "" {
-		model = "databricks-gpt-5-4"
+		model = defaultModel()
 	}
 	if modelExplicit {
 		saved := loadState()
@@ -653,7 +653,7 @@ Usage:
 
 Databricks-Codex Flags:
   --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
-  --model string        Model name (saved for future sessions; default: "databricks-gpt-5-4")
+  --model string        Model name (saved for future sessions; default: "databricks-gpt-5-5")
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
   --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
@@ -748,6 +748,24 @@ func handlePrintEnv(databricksHost, openaiBaseURL, token, profile, model, otelMe
   OTEL Logs Table:     %s
   Codex binary:        %s
 `, profile, model, databricksHost, openaiBaseURL, redacted, metricsLine, logsLine, codexPath)
+}
+
+// defaultModel returns the built-in default model name used when nothing else
+// (flag, env, saved state) is set. Centralised so tests can lock the default
+// against silent drift.
+func defaultModel() string { return "databricks-gpt-5-5" }
+
+// resolveModel returns the model name using the resolution chain:
+// --model flag → saved state → built-in default. The built-in default is
+// the only value that changes when the project bumps its default model.
+func resolveModel(flagValue string, savedValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if savedValue != "" {
+		return savedValue
+	}
+	return defaultModel()
 }
 
 // resolveProfile returns the Databricks CLI profile using the resolution chain:

--- a/main_test.go
+++ b/main_test.go
@@ -457,7 +457,7 @@ func TestHandlePrintEnv_RedactsAllTokenShapes(t *testing.T) {
 	for _, token := range tokens {
 		t.Run(fmt.Sprintf("token=%q", token), func(t *testing.T) {
 			out := captureStdout(func() {
-				handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", token, "DEFAULT", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+				handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", token, "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
 			})
 			if !strings.Contains(out, "**** (redacted)") {
 				t.Errorf("expected '**** (redacted)' in output, got:\n%s", out)
@@ -473,7 +473,7 @@ func TestHandlePrintEnv_NoLegacyDapiPrefix(t *testing.T) {
 	// Per #71, the legacy "dapi-***" branch was removed in favour of a single
 	// fixed redaction. Make sure no output ever contains the legacy form.
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "dapi-abc123", "DEFAULT", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "dapi-abc123", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
 	})
 	if strings.Contains(out, "dapi-***") {
 		t.Errorf("legacy 'dapi-***' redaction marker should be gone, got:\n%s", out)
@@ -482,7 +482,7 @@ func TestHandlePrintEnv_NoLegacyDapiPrefix(t *testing.T) {
 
 func TestHandlePrintEnv_ContainsProfile(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "aidev", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "aidev", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
 	})
 	if !strings.Contains(out, "aidev") {
 		t.Errorf("expected output to contain profile 'aidev', got:\n%s", out)
@@ -492,7 +492,7 @@ func TestHandlePrintEnv_ContainsProfile(t *testing.T) {
 func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 	host := "https://dbc-abc123.cloud.databricks.com"
 	out := captureStdout(func() {
-		handlePrintEnv(host, "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+		handlePrintEnv(host, "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
 	})
 	if !strings.Contains(out, host) {
 		t.Errorf("expected output to contain DATABRICKS_HOST %q, got:\n%s", host, out)
@@ -502,7 +502,7 @@ func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 func TestHandlePrintEnv_ContainsOpenAIBaseURL(t *testing.T) {
 	baseURL := "https://gw.example.com/openai/v1"
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", baseURL, "tok", "DEFAULT", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+		handlePrintEnv("https://dbc.example.com", baseURL, "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
 	})
 	if !strings.Contains(out, baseURL) {
 		t.Errorf("expected output to contain OPENAI_BASE_URL %q, got:\n%s", baseURL, out)
@@ -826,7 +826,7 @@ func TestResolveOtel(t *testing.T) {
 func TestHandlePrintEnv_ContainsOtelLogsTable(t *testing.T) {
 	table := "main.custom.otel_logs"
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-4", "main.codex_telemetry.codex_otel_metrics", table)
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", table)
 	})
 	if !strings.Contains(out, table) {
 		t.Errorf("expected output to contain OTEL Logs Table %q, got:\n%s", table, out)
@@ -839,7 +839,7 @@ func TestHandlePrintEnv_ContainsOtelLogsTable(t *testing.T) {
 func TestHandlePrintEnv_ContainsOtelMetricsTable(t *testing.T) {
 	table := "main.custom.otel_metrics"
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-4", table, "main.codex_telemetry.codex_otel_logs")
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", table, "main.codex_telemetry.codex_otel_logs")
 	})
 	if !strings.Contains(out, table) {
 		t.Errorf("expected output to contain OTEL Metrics Table %q, got:\n%s", table, out)
@@ -851,7 +851,7 @@ func TestHandlePrintEnv_ContainsOtelMetricsTable(t *testing.T) {
 
 func TestHandlePrintEnv_DisabledTablesRenderAsDisabled(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-4", "", "")
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "", "")
 	})
 	if !strings.Contains(out, "OTEL Metrics Table:  (disabled)") {
 		t.Errorf("expected '(disabled)' for metrics table when empty, got:\n%s", out)
@@ -971,5 +971,23 @@ func TestKnownFlagsCoverAllFlagDefs(t *testing.T) {
 		if !knownFlags[name] {
 			t.Errorf("flagDef %q is missing from knownFlags in completion_flags.go", name)
 		}
+	}
+}
+
+// TestResolveModel_DefaultIsGpt5_5 locks the built-in default model against
+// silent drift. When no flag is passed and saved state is empty, resolveModel
+// must return databricks-gpt-5-5. Bumping the default requires updating this
+// test in the same commit, which serves as an explicit checkpoint.
+func TestResolveModel_DefaultIsGpt5_5(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	// Empty saved state + no flag + no env → built-in default fires.
+	got := resolveModel("", loadState().Model)
+	want := "databricks-gpt-5-5"
+	if got != want {
+		t.Errorf("resolveModel default = %q, want %q", got, want)
 	}
 }

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -14,7 +14,7 @@ import (
 // PatchConfig holds the values to inject into config.toml.
 type PatchConfig struct {
 	ProxyURL            string // e.g., "http://127.0.0.1:54321"
-	Model               string // e.g., "databricks-gpt-5-4"
+	Model               string // e.g., "databricks-gpt-5-5"
 	ModelExplicit       bool   // true when --model was explicitly passed
 	OTELLogsEndpoint    string // e.g., "http://127.0.0.1:54321/otel/v1/logs"
 	OTELMetricsEndpoint string // e.g., "http://127.0.0.1:54321/otel/v1/metrics"

--- a/pkg/tomlconfig/tomlconfig_test.go
+++ b/pkg/tomlconfig/tomlconfig_test.go
@@ -42,7 +42,7 @@ func TestPatch_EmptyConfig(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestPatch_EmptyConfig(t *testing.T) {
 	if !strings.Contains(content, "[profiles.databricks-proxy]") {
 		t.Error("expected profiles section")
 	}
-	if !strings.Contains(content, `model = "databricks-gpt-5-4"`) {
+	if !strings.Contains(content, `model = "databricks-gpt-5-5"`) {
 		t.Error("expected model in profile section")
 	}
 	if !strings.Contains(content, `base_url = "http://127.0.0.1:9999"`) {
@@ -77,7 +77,7 @@ model = "gpt-4"
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ wire_api = "responses"
 	// ModelExplicit=false: should preserve user's model.
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
-		Model:         "databricks-gpt-5-4",
+		Model:         "databricks-gpt-5-5",
 		ModelExplicit: false,
 	})
 	if err != nil {
@@ -170,7 +170,7 @@ sandbox_permissions = "full-auto"
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +260,7 @@ shown = true
 
 	err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
-		Model:            "databricks-gpt-5-4",
+		Model:            "databricks-gpt-5-5",
 		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
 	})
 	if err != nil {
@@ -297,7 +297,7 @@ func TestRestore_NoOriginalFile(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +325,7 @@ trust_level = trusted
 	// Should pick up the root-level model.
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
-		Model:         "databricks-gpt-5-4",
+		Model:         "databricks-gpt-5-5",
 		ModelExplicit: false,
 	})
 	if err != nil {
@@ -336,7 +336,7 @@ trust_level = trusted
 	if !strings.Contains(content, `model = "databricks-gpt-5-3"`) {
 		t.Errorf("expected root-level model to be carried into profile section, got:\n%s", content)
 	}
-	if strings.Contains(content, `model = "databricks-gpt-5-4"`) {
+	if strings.Contains(content, `model = "databricks-gpt-5-5"`) {
 		t.Errorf("expected fallback model NOT to be used when root-level model exists, got:\n%s", content)
 	}
 }
@@ -370,7 +370,7 @@ func TestPatch_WithOTEL(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
-		Model:            "databricks-gpt-5-4",
+		Model:            "databricks-gpt-5-5",
 		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
 	})
 	if err != nil {
@@ -391,7 +391,7 @@ func TestPatch_WithOTELMetricsOnly(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
-		Model:               "databricks-gpt-5-4",
+		Model:               "databricks-gpt-5-5",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
 	})
 	if err != nil {
@@ -416,7 +416,7 @@ func TestPatch_WithBothOTELExporters(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
-		Model:               "databricks-gpt-5-4",
+		Model:               "databricks-gpt-5-5",
 		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
 	})
@@ -438,7 +438,7 @@ func TestPatch_NoOTELSectionWhenBothEmpty(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -459,7 +459,7 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	// First patch: logs only.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
-		Model:            "databricks-gpt-5-4",
+		Model:            "databricks-gpt-5-5",
 		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
 	}); err != nil {
 		t.Fatal(err)
@@ -468,7 +468,7 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	// Second patch: same proxy URL, now with metrics too.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
-		Model:               "databricks-gpt-5-4",
+		Model:               "databricks-gpt-5-5",
 		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
 	}); err != nil {
@@ -493,7 +493,7 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	// First patch: OTel enabled.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
-		Model:               "databricks-gpt-5-4",
+		Model:               "databricks-gpt-5-5",
 		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
 	}); err != nil {
@@ -508,7 +508,7 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	// Second patch: OTel disabled (both endpoints empty). Section must be gone.
 	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestUpdateProxyURL(t *testing.T) {
 
 	err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-4",
+		Model:    "databricks-gpt-5-5",
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Bump the built-in default model from `databricks-gpt-5-4` to `databricks-gpt-5-5`.

The resolution chain (`--model` flag → env → saved state → built-in default) is unchanged — only the *default* fires when nothing else is set. Existing users with a saved `Model` in `~/.codex/.databricks-codex.json` are unaffected.

## Changes

- `main.go` — default in model resolution (now via new `defaultModel()` helper + extracted `resolveModel()`), `--help` text
- `README.md` — defaults table
- `pkg/tomlconfig/tomlconfig.go` — example in struct field comment
- `main_test.go` — bumped default-asserting `handlePrintEnv` cases; **`-mini` override tests left untouched** (they test override behavior and must keep distinct values from the default)
- `pkg/tomlconfig/tomlconfig_test.go` — same: default-model assertions bumped, `-mini` overrides untouched
- Added `TestResolveModel_DefaultIsGpt5_5` — locks the default against silent drift; bumping it requires updating the test in the same commit

## Verification

- `go test ./... -count=1` — pass
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `make test` — pass
- `grep -rn 'gpt-5-4' --include='*.go' --include='*.md' .` — only `-mini` override fixtures remain

Closes #81
