### PR TITLE
feat: migrate hooks feature flag from codex_hooks to hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Install hooks so every Codex session auto-starts the proxy on startup — no man
 databricks-codex --install-hooks
 ```
 
-This merges a **SessionStart** hook into `~/.codex/hooks.json` and enables the `codex_hooks` feature flag in `~/.codex/config.toml`:
+This merges a **SessionStart** hook into `~/.codex/hooks.json` and enables the `hooks` feature flag in `~/.codex/config.toml`:
 
 - **SessionStart** (`startup`): runs `databricks-codex --headless-ensure` — starts the proxy if it isn't already running.
 

--- a/hooks.go
+++ b/hooks.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/IceRhymers/databricks-claude/pkg/headless"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
+
+// hooksKeyRegexp matches a `hooks` feature-flag assignment line. It is
+// anchored at start-of-line (after optional whitespace) and requires the key
+// be followed by whitespace or `=`, so it does NOT match the legacy
+// `codex_hooks` key.
+var hooksKeyRegexp = regexp.MustCompile(`(?m)^\s*hooks\s*=`)
 
 // headlessEnsure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
@@ -70,7 +77,7 @@ func installHooks(hooksPath string) error {
 		return err
 	}
 
-	// Codex CLI requires [features] codex_hooks = true to read hooks.json.
+	// Codex CLI requires [features] hooks = true to read hooks.json.
 	configPath := filepath.Join(filepath.Dir(hooksPath), "config.toml")
 	return ensureHooksFeatureFlag(configPath)
 }
@@ -101,7 +108,14 @@ func uninstallHooks(hooksPath string) error {
 		doc["hooks"] = hooks
 	}
 
-	return writeHooksDoc(hooksPath, doc)
+	if err := writeHooksDoc(hooksPath, doc); err != nil {
+		return err
+	}
+
+	// Remove our `hooks = true` from config.toml. Legacy `codex_hooks =` lines
+	// are left untouched — we never migrate user-authored keys.
+	configPath := filepath.Join(filepath.Dir(hooksPath), "config.toml")
+	return removeHooksFeatureFlag(configPath)
 }
 
 // removeDBXHooks removes any hook entries whose command contains "databricks-codex --headless".
@@ -199,10 +213,14 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-// ensureHooksFeatureFlag ensures config.toml contains codex_hooks = true
-// inside a [features] section. Surgical: if the key already exists it's a
-// no-op; if [features] exists the key is appended inside it; otherwise a
-// new section is appended at the end.
+// ensureHooksFeatureFlag ensures config.toml contains `hooks = true`
+// inside a [features] section. Surgical: if the new `hooks` key is already
+// present it's a no-op; if [features] exists the key is appended inside it;
+// otherwise a new section is appended at the end.
+//
+// Detection is anchored — a legacy `codex_hooks = ...` line is NOT treated
+// as enabled, and is never read, rewritten, or removed by this function.
+// If both keys end up coexisting, upstream Codex tolerates that.
 //
 // TODO(#72 follow-up): This writes directly to the same config.toml that
 // tomlconfig.Manager owns, bypassing the manager's backup/restore bookkeeping.
@@ -216,8 +234,9 @@ func ensureHooksFeatureFlag(configPath string) error {
 	}
 	content := string(data)
 
-	// Already enabled — nothing to do.
-	if strings.Contains(content, "codex_hooks") {
+	// Already enabled — nothing to do. Anchored match so `codex_hooks` does
+	// not satisfy this check.
+	if hooksKeyRegexp.MatchString(content) {
 		return nil
 	}
 
@@ -230,7 +249,7 @@ func ensureHooksFeatureFlag(configPath string) error {
 			end = len(content[idx:])
 		}
 		insertAt := idx + end
-		content = content[:insertAt] + "\ncodex_hooks = true" + content[insertAt:]
+		content = content[:insertAt] + "\nhooks = true" + content[insertAt:]
 	} else {
 		// Append a new [features] section.
 		sep := "\n"
@@ -239,11 +258,70 @@ func ensureHooksFeatureFlag(configPath string) error {
 		} else if len(content) > 0 {
 			sep = "\n"
 		}
-		content += sep + "[features]\ncodex_hooks = true\n"
+		content += sep + "[features]\nhooks = true\n"
 	}
 
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
 	return atomicWriteFile(configPath, []byte(content), 0o600)
+}
+
+// removeHooksFeatureFlag removes any line that assigns the new `hooks` key
+// inside config.toml. It performs an anchored, line-oriented match so the
+// legacy `codex_hooks =` key — and any other user-authored content — is
+// preserved byte-identical.
+//
+// If the file does not exist, or contains no matching line, this is a no-op.
+func removeHooksFeatureFlag(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading config.toml: %w", err)
+	}
+	content := string(data)
+	if !hooksKeyRegexp.MatchString(content) {
+		return nil
+	}
+
+	// Walk the file line by line and drop only the lines whose trimmed
+	// prefix is the new `hooks` key (followed by whitespace or `=`).
+	var b strings.Builder
+	b.Grow(len(content))
+	start := 0
+	for i := 0; i <= len(content); i++ {
+		if i == len(content) || content[i] == '\n' {
+			line := content[start:i]
+			if !isNewHooksAssignmentLine(line) {
+				b.WriteString(line)
+				if i < len(content) {
+					b.WriteByte('\n')
+				}
+			}
+			start = i + 1
+		}
+	}
+	out := b.String()
+	if out == content {
+		return nil
+	}
+	return atomicWriteFile(configPath, []byte(out), 0o600)
+}
+
+// isNewHooksAssignmentLine reports whether a single line (no trailing
+// newline) is an assignment of the new `hooks` feature flag. The check is
+// anchored so `codex_hooks = ...` returns false.
+func isNewHooksAssignmentLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "hooks") {
+		return false
+	}
+	rest := trimmed[len("hooks"):]
+	if len(rest) == 0 {
+		return false
+	}
+	c := rest[0]
+	return c == ' ' || c == '\t' || c == '='
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -261,6 +261,185 @@ func TestWriteHooksDoc_AtomicReplace(t *testing.T) {
 	}
 }
 
+// TestEnsureHooksFeatureFlag_NoFeaturesSection verifies that if config.toml
+// has no [features] section, one is created with `hooks = true`.
+func TestEnsureHooksFeatureFlag_NoFeaturesSection(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "model = \"gpt-5\"\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "[features]") {
+		t.Errorf("expected [features] section, got:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_FeaturesSectionWithOtherKey verifies that
+// `hooks = true` is inserted under an existing [features] section.
+func TestEnsureHooksFeatureFlag_FeaturesSectionWithOtherKey(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\nfoo = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "foo = true") {
+		t.Errorf("expected foo = true preserved, got:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_AlreadyEnabled verifies no-op when `hooks = true`
+// already present.
+func TestEnsureHooksFeatureFlag_AlreadyEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	if string(got) != original {
+		t.Errorf("expected no-op, got:\n%s", got)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_LegacyOnlyAppendsNew verifies that if only the
+// legacy `codex_hooks = true` is present, `hooks = true` is appended and the
+// legacy line survives BYTE-IDENTICAL.
+func TestEnsureHooksFeatureFlag_LegacyOnlyAppendsNew(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\ncodex_hooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "codex_hooks = true") {
+		t.Errorf("legacy codex_hooks line was modified or removed:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line appended, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_BothKeys verifies no-op when both keys present.
+func TestEnsureHooksFeatureFlag_BothKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\ncodex_hooks = true\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	if string(got) != original {
+		t.Errorf("expected no-op, got:\n%s", got)
+	}
+}
+
+// TestUninstallHooks_RemovesNewKeyPreservesLegacy verifies that
+// --uninstall-hooks removes only `hooks =` from config.toml, leaving any
+// legacy `codex_hooks =` line untouched.
+func TestUninstallHooks_RemovesNewKeyPreservesLegacy(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+	cfg := filepath.Join(dir, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := "[features]\ncodex_hooks = true\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	if err := uninstallHooks(hooksPath); err != nil {
+		t.Fatalf("uninstallHooks: %v", err)
+	}
+
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "codex_hooks = true") {
+		t.Errorf("legacy codex_hooks line should survive uninstall, got:\n%s", s)
+	}
+	if hasNewHooksLine(s) {
+		t.Errorf("`hooks = true` line should be removed by uninstall, got:\n%s", s)
+	}
+}
+
+// containsLine returns true if any line of s exactly equals target after
+// trimming trailing whitespace.
+func containsLine(s, target string) bool {
+	for _, line := range splitLines(s) {
+		if line == target {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNewHooksLine returns true if any line is the canonical `hooks = true`
+// (anchored — not matching `codex_hooks`).
+func hasNewHooksLine(s string) bool {
+	for _, line := range splitLines(s) {
+		trimmed := line
+		for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t') {
+			trimmed = trimmed[1:]
+		}
+		if trimmed == "hooks = true" {
+			return true
+		}
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
 // TestIsDBXHookEntry verifies detection of databricks-codex hook entries.
 func TestIsDBXHookEntry(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Closes #82

## Summary

Codex v0.130.x renamed the `[features].codex_hooks` flag to `[features].hooks` and now prints a deprecation warning on every wrapper invocation. This PR migrates the wrapper to write the new canonical key while leaving any user-authored `codex_hooks` key strictly untouched.

## Changes

- `ensureHooksFeatureFlag` now writes `hooks = true` (the new canonical key).
- Detection uses an anchored regex `(?m)^\s*hooks\s*=` plus a line-oriented helper, so the legacy `codex_hooks` key is **never** treated as enabled and is never read.
- Added `removeHooksFeatureFlag`, called from `uninstallHooks`, which removes only the new `hooks =` line. Legacy `codex_hooks =` lines survive byte-identical through both install and uninstall.
- README snippet updated to reference the new flag name (no migration claim).

## Hard guarantees

- The wrapper does **not** migrate, rewrite, or delete user-authored config keys.
- If a user already has `codex_hooks = true`, `--install-hooks` appends `hooks = true` alongside it (upstream tolerates both).
- The legacy line is preserved byte-identical through both install and uninstall, asserted by tests.

## Tests added

`TestEnsureHooksFeatureFlag_*`:
- `NoFeaturesSection` – section is created with `hooks = true`
- `FeaturesSectionWithOtherKey` – `hooks = true` inserted under existing section
- `AlreadyEnabled` – no-op when `hooks = true` already present
- `LegacyOnlyAppendsNew` – legacy `codex_hooks = true` preserved byte-identical, `hooks = true` appended
- `BothKeys` – no-op when both keys present

`TestUninstallHooks_RemovesNewKeyPreservesLegacy` – `--uninstall-hooks` removes only the new `hooks =` line; the legacy `codex_hooks =` line survives.

`go test ./... -count=1`, `go vet ./...`, and `gofmt -l .` are all clean.
