### PR TITLE
feat: CLI command-tree restructure (integration branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'feat/**']
   pull_request:
-    branches: [master]
+    branches: [master, 'feat/**']
 
 jobs:
   ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,12 @@ Transparent wrapper for the OpenAI Codex CLI that auto-injects Databricks OAuth 
 
 | File | Description |
 |------|-------------|
-| `main.go` | CLI entry point: flag parsing, resolution chains for profile/model/otel-logs-table, proxy startup, config.toml patching, and Codex child process lifecycle |
+| `main.go` | CLI entry point: flag parsing, resolution chains for profile/model/otel-logs-table, `runProxyMode` launcher, config.toml patching, and Codex child process lifecycle. `runProxyMode` is shared by the transparent-wrapper path and the `serve` subcommand path. |
+| `serve_cmd.go` | `runServeCommand` dispatcher for the `serve` subcommand (#89). Replaces the legacy `--headless` / `--idle-timeout` root flags. Constructs an `Args` struct with `Headless=true` and the parsed idle timeout, then calls `runProxyMode`. |
+| `cli_config.go` | `runConfigCommand` dispatcher for the `config` subcommand (#87). Persistent-config editor for OTEL signals + diagnostic `config show`. |
+| `hooks.go` | `headlessEnsure` / `installHooks` / `uninstallHooks`. The hook spawn path now invokes `databricks-codex serve --port=N` (#89) — set via `headless.Config.EnsureCommand`. |
+| `hooks_cmd.go` | `runHooksCommand` dispatcher for the `hooks` subcommand (#88). install / uninstall / session-start. |
+| `commands.go` | Source-of-truth `cmd.Command` declarations: `rootCommand`, `configCommand`, `hooksCommand`, `serveCommand`. Drives `parseArgs`, completion scripts, and help rendering. |
 | `token.go` | `databricksFetcher` implements `tokencache.TokenFetcher` via `databricks auth token`. Also `DiscoverHost` (via `databricks auth env`) and `ConstructGatewayURL` (SCIM `/Me` for workspace ID) |
 | `config.go` | `ConfigManager` coordinates tomlconfig, filelock, and session registry. `Setup()` backs up + patches; `Restore()` handles multi-session handoff or full restore |
 | `state.go` | `persistentState` JSON at `~/.codex/.databricks-codex.json` — persists profile, model, and otel-logs-table across sessions |

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 | `--tls-key` | | TLS private key file for the local proxy (requires `--tls-cert`) |
 | `--headless` | `false` | Start proxy without launching codex (for IDE extensions or hooks) |
 | `--idle-timeout` | `30m` | Idle timeout for headless mode (`0` disables; bare number = minutes) |
-| `--install-hooks` | | Install SessionStart hook into `~/.codex/hooks.json` |
-| `--uninstall-hooks` | | Remove databricks-codex hooks from `~/.codex/hooks.json` |
 | `--version` | | Print version and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `codex --help` output, then exit |
+
+Hook installation lives under `databricks-codex hooks` (see [`hooks` Subcommand](#hooks-subcommand)).
 
 All other flags and args are forwarded to `codex`.
 
@@ -161,21 +161,27 @@ This lets the wrapper:
 
 `databricks-codex --help` (or `-h`) prints the wrapper's own flags followed by the complete `codex --help` output.
 
-## Session Hooks (automatic proxy lifecycle)
+## `hooks` Subcommand
 
-Install hooks so every Codex session auto-starts the proxy on startup — no manual `--headless` needed.
+Install hooks so every Codex session auto-starts the proxy on startup — no manual `--headless` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
 
 > **First-time setup:** Run `databricks-codex` at least once before installing hooks. This writes `~/.codex/config.toml` so the proxy is used for all Codex sessions.
+
+| Subcommand | Purpose |
+| --- | --- |
+| `databricks-codex hooks install` | Install SessionStart hook into `~/.codex/hooks.json` |
+| `databricks-codex hooks uninstall` | Remove databricks-codex hooks from `~/.codex/hooks.json` |
+| `databricks-codex hooks session-start` | Hook-invoked internal — start proxy if not running |
 
 ### Install
 
 ```bash
-databricks-codex --install-hooks
+databricks-codex hooks install
 ```
 
 This merges a **SessionStart** hook into `~/.codex/hooks.json` and enables the `hooks` feature flag in `~/.codex/config.toml`:
 
-- **SessionStart** (`startup`): runs `databricks-codex --headless-ensure` — starts the proxy if it isn't already running.
+- **SessionStart** (`startup`): runs `databricks-codex hooks session-start` — starts the proxy if it isn't already running.
 
 ### Shutdown
 
@@ -184,15 +190,16 @@ Unlike Claude Code, the Codex CLI does not have a `SessionEnd` hook event. The p
 ### Uninstall
 
 ```bash
-databricks-codex --uninstall-hooks
+databricks-codex hooks uninstall
 ```
 
 Removes only the databricks-codex hook entries. Other hooks in your `hooks.json` are untouched.
 
 ### Notes
 
-- Safe to rerun `--install-hooks` after upgrades — existing hooks are replaced, not duplicated.
+- Safe to rerun `hooks install` after upgrades — existing hooks are replaced, not duplicated.
 - Custom port settings persist automatically via the state file (`~/.codex/.databricks-codex.json`).
+- `hooks session-start` is wired by `hooks install` for you; running it manually is a no-op when the proxy is already up.
 
 ## Shell Tab Completions
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,6 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 |------|---------|-------------|
 | `--verbose`, `-v` | `false` | Enable debug logging to stderr |
 | `--log-file` | | Write debug logs to a file (combinable with `--verbose`) |
-| `--print-env` | | Print resolved configuration (token redacted) and exit |
-| `--otel` | `false` | Enable OpenTelemetry export (metrics + logs) |
-| `--no-otel` | | Disable OpenTelemetry for this session (saved tables preserved) |
-| `--otel-metrics-table` | `main.codex_telemetry.codex_otel_metrics` (when `--otel` is set) | Unity Catalog table for OpenTelemetry metrics |
-| `--otel-logs-table` | derived from metrics table when omitted | Unity Catalog table for OpenTelemetry logs |
-| `--no-otel-metrics` | | Disable metrics for this session (saved table preserved) |
-| `--no-otel-logs` | | Disable logs for this session (saved table preserved) |
 | `--profile` | saved/`DEFAULT` | Databricks CLI profile (saved to state file; `--profile` flag writes it once) |
 | `--model` | `databricks-gpt-5-5` | Model to use (saved for future sessions) |
 | `--port` | `49154` | Proxy listen port (saved for future sessions) |
@@ -109,6 +102,43 @@ Hook installation lives under `databricks-codex hooks` (see [`hooks` Subcommand]
 
 All other flags and args are forwarded to `codex`.
 
+> **Breaking in v0.12.0:** the persistent-config root flags `--otel`,
+> `--no-otel`, `--no-otel-metrics`, `--no-otel-logs`, `--otel-metrics-table`,
+> `--otel-logs-table`, and `--print-env` are gone. They moved under
+> `databricks-codex config` — see the [config Subcommand](#config-subcommand)
+> section below.
+
+## config Subcommand
+
+`databricks-codex config <subcommand>` is the persistent-config editor.
+Mutations are written to `~/.codex/.databricks-codex.json` (the state file)
+so they take effect on the **next** `databricks-codex` invocation; the
+session you're currently in is unaffected. `~/.codex/config.toml` is not
+touched by `config.*` commands — it is owned by the proxy lifecycle and
+re-emitted at every session start based on the state file.
+
+| Command | Replaces | Description |
+|---------|----------|-------------|
+| `config otel enable [--metrics-table T] [--logs-table T] [--profile P]` | `--otel`, `--otel-metrics-table`, `--otel-logs-table` | Persist OTEL table preferences. Logs table derives from metrics table when only `--metrics-table` is given. With no flags and no saved state, applies the legacy default `main.codex_telemetry.codex_otel_metrics`. |
+| `config otel disable [--metrics] [--logs]` | `--no-otel`, `--no-otel-metrics`, `--no-otel-logs` | Mark OTEL signals off in state. With no flags, both signals disabled (legacy `--no-otel` semantics). Table-name preferences are **preserved** — a future `config otel enable` restores them without re-typing. |
+| `config show` | `--print-env` | Print the resolved configuration (token redacted) and exit. Read-only. |
+
+```bash
+# Enable with custom metrics + logs tables — table names persist to state:
+databricks-codex config otel enable \
+  --metrics-table main.codex_telemetry.codex_otel_metrics \
+  --logs-table   main.codex_telemetry.codex_otel_logs
+
+# Disable just metrics; logs keep exporting on the next session:
+databricks-codex config otel disable --metrics
+
+# Disable both signals (legacy --no-otel) — table names remain in state:
+databricks-codex config otel disable
+
+# Re-enable later — saved tables resurface, no re-typing:
+databricks-codex config otel enable
+```
+
 ## Auto-Discovery
 
 On startup, `databricks-codex` auto-discovers:
@@ -120,10 +150,10 @@ On startup, `databricks-codex` auto-discovers:
 
 ### Verify your resolved configuration
 
-Run `--print-env` to print the resolved profile, Databricks host, upstream base URL, redacted token placeholder, OpenTelemetry metrics and logs tables, and detected Codex binary path, then exit without launching Codex.
+Run `config show` to print the resolved profile, Databricks host, upstream base URL, redacted token placeholder, OpenTelemetry metrics and logs tables, and detected Codex binary path, then exit without launching Codex.
 
 ```bash
-databricks-codex --print-env
+databricks-codex config show
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -93,11 +93,10 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 | `--proxy-api-key` | disabled | Require this API key on all local proxy requests |
 | `--tls-cert` | | TLS certificate file for the local proxy (requires `--tls-key`) |
 | `--tls-key` | | TLS private key file for the local proxy (requires `--tls-cert`) |
-| `--headless` | `false` | Start proxy without launching codex (for IDE extensions or hooks) |
-| `--idle-timeout` | `30m` | Idle timeout for headless mode (`0` disables; bare number = minutes) |
 | `--version` | | Print version and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `codex --help` output, then exit |
 
+Headless / idle-timeout knobs live under `databricks-codex serve` (see [`serve` Subcommand](#serve-subcommand)).
 Hook installation lives under `databricks-codex hooks` (see [`hooks` Subcommand](#hooks-subcommand)).
 
 All other flags and args are forwarded to `codex`.
@@ -107,6 +106,13 @@ All other flags and args are forwarded to `codex`.
 > `--otel-logs-table`, and `--print-env` are gone. They moved under
 > `databricks-codex config` — see the [config Subcommand](#config-subcommand)
 > section below.
+
+> **Breaking in v0.13.0:** the session-mode root flags `--headless` and
+> `--idle-timeout` are gone. They moved under `databricks-codex serve` —
+> see the [serve Subcommand](#serve-subcommand) section below. The
+> SessionStart hook installed by `databricks-codex hooks install`
+> continues to work transparently — it spawns `databricks-codex serve`
+> internally now.
 
 ## config Subcommand
 
@@ -191,9 +197,47 @@ This lets the wrapper:
 
 `databricks-codex --help` (or `-h`) prints the wrapper's own flags followed by the complete `codex --help` output.
 
+## serve Subcommand
+
+`databricks-codex serve` runs the proxy in headless mode without launching `codex`. Useful when an IDE extension or other tool needs the proxy up but doesn't want a child `codex` process. Replaces the legacy root flags `--headless` and `--idle-timeout`, which were removed in v0.13.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--idle-timeout` | `30m` | Shut the proxy down after this much idle time. `0` disables (long-running IDE sessions). Accepts Go duration strings: `30s`, `5m`, `1h`, `2h30m`. Bare integers (e.g. `30`) are rejected. |
+| `--profile` | state file > `DEFAULT` | Databricks CLI profile. |
+| `--port` | state file > `49154` | Proxy listen port. |
+| `--model` | saved | Model name (saved to state file when supplied). |
+| `--upstream` | auto-discovered | Override the AI Gateway URL. |
+| `--log-file` | | Write debug logs to this file (combinable with `--verbose`). |
+| `--verbose`, `-v` | `false` | Enable debug logging to stderr. |
+| `--proxy-api-key` | disabled | Require this API key on all proxy requests. |
+| `--tls-cert` | | TLS certificate file (requires `--tls-key`). |
+| `--tls-key` | | TLS private key file (requires `--tls-cert`). |
+| `--no-update-check` | | Skip the automatic update check on startup. |
+| `--help`, `-h` | | Show help and exit. |
+
+The proxy prints `PROXY_URL=http://127.0.0.1:<port>` (or `https://...` with TLS) to stdout once bound. It exits when:
+
+- `SIGINT` or `SIGTERM` is received.
+- `POST /shutdown` is hit on the proxy URL.
+- `--idle-timeout` elapses with zero in-flight requests.
+
+```bash
+# Default 30-minute idle timeout:
+databricks-codex serve
+
+# Tight timeout for tests / CI:
+databricks-codex serve --idle-timeout 5m
+
+# Disable idle shutdown for a long-running IDE session:
+databricks-codex serve --idle-timeout 0
+```
+
+The SessionStart hook installed by `databricks-codex hooks install` spawns `databricks-codex serve` under the hood — you don't need to invoke this manually for the hooks path.
+
 ## `hooks` Subcommand
 
-Install hooks so every Codex session auto-starts the proxy on startup — no manual `--headless` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
+Install hooks so every Codex session auto-starts the proxy on startup — no manual `databricks-codex serve` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
 
 > **First-time setup:** Run `databricks-codex` at least once before installing hooks. This writes `~/.codex/config.toml` so the proxy is used for all Codex sessions.
 
@@ -215,7 +259,7 @@ This merges a **SessionStart** hook into `~/.codex/hooks.json` and enables the `
 
 ### Shutdown
 
-Unlike Claude Code, the Codex CLI does not have a `SessionEnd` hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `--idle-timeout`). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
+Unlike Claude Code, the Codex CLI does not have a `SessionEnd` hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `databricks-codex serve --idle-timeout <dur>` for direct invocations; the SessionStart hook spawns the proxy with the default 30-minute timeout). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
 
 ### Uninstall
 

--- a/cli_config.go
+++ b/cli_config.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// runConfigCommand implements the `databricks-codex config ...` dispatcher.
+// args is everything after the literal "config" token. Routes to the otel
+// or show runner. Bare `config` (no args) prints help and exits 2 — same
+// convention as the rest of the binary's subcommand-with-no-action paths.
+//
+// The persistent-config editor was previously a sprawl of 7 root flags
+// (--otel, --no-otel*, --otel-*-table, --print-env); #87 consolidates them
+// under this tree and removes them from the root. Storage semantics — state
+// file table preservation across `config otel disable`, [otel] section
+// removal (not just skip-the-write) when both signals are off — are
+// unchanged; this is a pure surface reshape. The pure-function resolver
+// (resolveConfigOTEL) makes the orchestration matrix testable in isolation;
+// helper-level tests passing while composition is broken is the known
+// failure mode for this kind of refactor, and the matrix test in
+// cli_config_test.go is the safety net.
+func runConfigCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "otel":
+		runConfigOTEL(args[1:])
+	case "show":
+		runConfigShow(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, configCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-codex: unknown config subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// configOTELResolution is the pure-function projection of the OTEL enable
+// resolution chain. Extracted so the orchestration matrix test (state
+// empty/populated × explicit table flags × derive-logs-from-metrics) can
+// drive it in isolation. Caller is responsible for the post-resolve state
+// persistence write.
+type configOTELResolution struct {
+	MetricsTable string
+	LogsTable    string
+	NewState     persistentState // state to persist (callers gate the write on StateMutated)
+	StateMutated bool            // true when NewState differs from the input saved state
+}
+
+// resolveConfigOTEL performs the OTEL enable-side resolution that the legacy
+// resolveOtel did inline for the regular session path. Pure function: no
+// I/O, no global state, no defaults applied at this layer. Drives the
+// orchestration matrix test (#87 acceptance criterion).
+//
+// Resolution chain per signal: explicit flag > saved state > (logs only:
+// derive from metrics) > unset. The bare-toggle metrics default (the legacy
+// `else if metricsTable == "" && a.Otel` branch in main.go) is applied by
+// the caller (runConfigOTELEnable), NOT here — this mirrors the pattern
+// caught in databricks-claude PR #172 round-1 review where a shared
+// resolver applying a default that only one caller should get is the bug
+// class. Codex's surface only has one caller right now (`config otel
+// enable`), but keeping the resolver pure makes it easier to reuse if the
+// future #88/#89 work needs it.
+//
+// The Disabled flags on the input saved state are CLEARED in NewState
+// (config otel enable un-sticks a previous disable). Sentinel-guard the
+// persist: NewState is only meaningfully different when an explicit flag
+// was passed OR a Disabled flag was previously set.
+func resolveConfigOTEL(
+	saved persistentState,
+	metricsTableFlag string, metricsTableSet bool,
+	logsTableFlag string, logsTableSet bool,
+) configOTELResolution {
+	r := configOTELResolution{
+		MetricsTable: saved.OtelMetricsTable,
+		LogsTable:    saved.OtelLogsTable,
+		NewState:     saved,
+	}
+
+	if metricsTableSet {
+		r.MetricsTable = metricsTableFlag
+	}
+
+	if logsTableSet {
+		r.LogsTable = logsTableFlag
+	} else if r.LogsTable == "" && r.MetricsTable != "" {
+		r.LogsTable = deriveLogsTable(r.MetricsTable)
+	}
+
+	mutated := false
+	if metricsTableSet && r.MetricsTable != "" && r.NewState.OtelMetricsTable != r.MetricsTable {
+		r.NewState.OtelMetricsTable = r.MetricsTable
+		mutated = true
+	}
+	if logsTableSet && r.LogsTable != "" && r.NewState.OtelLogsTable != r.LogsTable {
+		r.NewState.OtelLogsTable = r.LogsTable
+		mutated = true
+	}
+	// Enable always clears any sticky disable bit so the next session emits
+	// the [otel] section. If neither was set, no mutation.
+	if r.NewState.OtelMetricsDisabled {
+		r.NewState.OtelMetricsDisabled = false
+		mutated = true
+	}
+	if r.NewState.OtelLogsDisabled {
+		r.NewState.OtelLogsDisabled = false
+		mutated = true
+	}
+	r.StateMutated = mutated
+	return r
+}
+
+// runConfigOTEL implements `databricks-codex config otel <enable|disable>`.
+func runConfigOTEL(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "databricks-codex: 'config otel' requires a subcommand: enable or disable")
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "enable":
+		runConfigOTELEnable(args[1:])
+	case "disable":
+		runConfigOTELDisable(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, *configCommand.Subcommand("otel"), nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-codex: unknown config otel subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(1)
+	}
+}
+
+// runConfigOTELEnable implements `databricks-codex config otel enable`.
+// Persists the resolved table preferences to the state file. config.toml is
+// NOT touched — the proxy lifecycle re-emits the [otel] section based on
+// state at the next session start.
+func runConfigOTELEnable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("enable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	profile := r.Strings["profile"]
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	// Validate profile reachability before persisting anything — fail fast
+	// with an actionable error rather than writing state for a profile that
+	// is broken at next session start.
+	if _, err := DiscoverHost("", profile); err != nil {
+		log.Fatalf("databricks-codex: config otel enable: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+
+	res := resolveConfigOTEL(
+		saved,
+		r.Strings["metrics-table"], r.Set["metrics-table"],
+		r.Strings["logs-table"], r.Set["logs-table"],
+	)
+
+	// Caller-level metrics default: a bare `config otel enable` (no flags,
+	// empty state) inherits the legacy --otel default table. The resolver
+	// itself is kept pure so it never invents a table name; the default
+	// fallback is the caller's policy decision. Mirrors the
+	// applyMetricsDefault gate in databricks-claude's resolveConfigOTEL,
+	// implemented here as a caller-side branch since codex only has one
+	// caller (no shared resolver to risk).
+	if res.MetricsTable == "" && !r.Set["metrics-table"] && !r.Set["logs-table"] {
+		res.MetricsTable = "main.codex_telemetry.codex_otel_metrics"
+		if res.LogsTable == "" {
+			res.LogsTable = deriveLogsTable(res.MetricsTable)
+		}
+		// Bare-toggle default is intentionally NOT persisted to state — the
+		// next session resolves the same default fresh if state is still
+		// empty. Persisting it would silently lock a fleet to a default the
+		// user never asked for.
+	}
+
+	if res.StateMutated {
+		if err := saveState(res.NewState); err != nil {
+			log.Fatalf("databricks-codex: config otel enable: could not persist OTEL tables: %v", err)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "databricks-codex: OTEL enabled (profile=%s, metrics=%s, logs=%s). Take effect on next 'databricks-codex' invocation.\n",
+		profile, displayTableOrNone(res.MetricsTable), displayTableOrNone(res.LogsTable))
+}
+
+// runConfigOTELDisable implements `databricks-codex config otel disable`.
+// Sets the per-signal "disabled" sticky bits in the state file. The proxy
+// lifecycle reads these on the next session start and removes the [otel]
+// section from config.toml when all signals are off. Table-name
+// preferences are PRESERVED so a future `config otel enable` restores them.
+func runConfigOTELDisable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("disable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	clearMetrics := r.Bools["metrics"]
+	clearLogs := r.Bools["logs"]
+
+	// No flags = both signals (the legacy --no-otel nuclear option).
+	if !clearMetrics && !clearLogs {
+		clearMetrics = true
+		clearLogs = true
+	}
+
+	mutated := false
+	if clearMetrics && !saved.OtelMetricsDisabled {
+		saved.OtelMetricsDisabled = true
+		mutated = true
+	}
+	if clearLogs && !saved.OtelLogsDisabled {
+		saved.OtelLogsDisabled = true
+		mutated = true
+	}
+
+	if mutated {
+		if err := saveState(saved); err != nil {
+			log.Fatalf("databricks-codex: config otel disable: could not persist OTEL disable: %v", err)
+		}
+	}
+
+	switch {
+	case clearMetrics && clearLogs:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL disabled — [otel] section will be removed from config.toml on the next session start (state file table preferences preserved)")
+	case clearMetrics:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL metrics disabled (logs preserved if previously enabled; state file table preferences preserved)")
+	case clearLogs:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL logs disabled (metrics preserved if previously enabled; state file table preferences preserved)")
+	}
+}
+
+// runConfigShow implements `databricks-codex config show` — the legacy
+// --print-env flow lifted into a subcommand. Read-only diagnostic.
+func runConfigShow(args []string) {
+	node := configCommand.Subcommand("show")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	profile := r.Strings["profile"]
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	host, err := DiscoverHost("", profile)
+	if err != nil {
+		log.Fatalf("databricks-codex: config show: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+	gatewayURL := ConstructGatewayURL(host)
+
+	tp := NewTokenProvider("", profile)
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		log.Fatalf("databricks-codex: config show: failed to fetch token for profile %q: %v", profile, err)
+	}
+
+	model := resolveModel("", saved.Model)
+
+	// resolveOtel reads from saved state (no flag input — the session
+	// flags are gone with #87). Mirrors what the regular session path
+	// will read at next start.
+	_, metricsTable, logsTable := resolveOtel(saved)
+
+	handlePrintEnv(host, gatewayURL, token, profile, model, metricsTable, logsTable)
+}
+
+// displayTableOrNone returns the literal table name or "(none)" when empty,
+// for the confirmation log line emitted by `config otel enable`.
+func displayTableOrNone(t string) string {
+	if t == "" {
+		return "(none)"
+	}
+	return t
+}

--- a/cli_config_test.go
+++ b/cli_config_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// --- #87 config tree parity tests ---
+//
+// Bidirectional contract: every flag declared on a config leaf must be
+// consumed by its runner, and every flag the runner consumes must be
+// declared on the leaf. The hand-rolled flag scanners in cli_config.go
+// drive parseResult lookups; the only way to fail loudly when one side
+// drifts is an explicit per-leaf parity test.
+//
+// Bidirectional-verification note: temporarily removing configCommand
+// from rootCommand.Subcommands fails TestRootHasConfigSubcommand; adding
+// an extra flag to a leaf without wiring it into the runner fails the
+// `assertConfigFlagSetEqual` "declares but does not consume" arm. Both
+// directions exercised manually during #87 development to confirm the
+// parity tests fire.
+
+func TestConfigCommandParity(t *testing.T) {
+	assertConfigFlagSetEqual(t, "configCommand", configCommand, []string{})
+}
+
+func TestConfigOTELEnableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	enable := otel.Subcommand("enable")
+	if enable == nil {
+		t.Fatal("config otel should have an `enable` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config otel enable", *enable, []string{
+		"metrics-table", "logs-table", "profile", "help",
+	})
+}
+
+func TestConfigOTELDisableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	disable := otel.Subcommand("disable")
+	if disable == nil {
+		t.Fatal("config otel should have a `disable` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config otel disable", *disable, []string{
+		"metrics", "logs", "help",
+	})
+}
+
+func TestConfigShowParity(t *testing.T) {
+	show := configCommand.Subcommand("show")
+	if show == nil {
+		t.Fatal("configCommand should have a `show` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config show", *show, []string{"profile", "help"})
+}
+
+// TestConfigHasNestedSubcommands asserts the otel/show children are declared
+// so completion can offer them nested. Locks in the surface of the new tree.
+func TestConfigHasNestedSubcommands(t *testing.T) {
+	want := []string{"otel", "show"}
+	got := make(map[string]bool, len(configCommand.Subcommands))
+	for _, s := range configCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("configCommand should have nested `%s` subcommand", w)
+		}
+	}
+}
+
+// TestRootHasConfigSubcommand is the structural counterpart to the breaking
+// change in #87: the root tree must declare config so dispatch from
+// main.go (and shell completion) finds it.
+func TestRootHasConfigSubcommand(t *testing.T) {
+	for _, s := range rootCommand.Subcommands {
+		if s.Name == "config" {
+			return
+		}
+	}
+	t.Error("rootCommand must declare a `config` subcommand (the surface introduced in #87)")
+}
+
+// TestRootCommandLegacyOTELFlagsRemoved locks the breaking surface change
+// from #87: the legacy --otel*/--print-env flags must NOT appear on
+// rootCommand any more. If a future refactor accidentally re-adds one, this
+// test fires and points at the migration sub-issue.
+func TestRootCommandLegacyOTELFlagsRemoved(t *testing.T) {
+	declared := flagNameSetForConfig(rootCommand)
+	for _, flag := range []string{
+		"otel", "no-otel", "no-otel-metrics", "no-otel-logs",
+		"otel-metrics-table", "otel-logs-table",
+		"print-env",
+	} {
+		if declared[flag] {
+			t.Errorf("rootCommand still declares --%s after #87 migration; the user-facing flag must move to `config otel ...` / `config show`", flag)
+		}
+	}
+}
+
+// --- #87 OTEL orchestration matrix test ---
+//
+// AC requirement: "Orchestration matrix test ported: state empty/populated
+// × explicit table flags — assert the final resolved (metricsTable,
+// logsTable) tuple plus the persisted state shape."
+//
+// Drives the pure resolveConfigOTEL function. Helper-level tests passing
+// while composition is broken is the known failure mode for refactors of
+// this shape; this matrix covers the cross-product so a regression in any
+// branch of the resolver fails the suite loudly.
+
+func TestResolveConfigOTEL_OrchestrationMatrix(t *testing.T) {
+	emptyState := persistentState{}
+	populatedState := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+		OtelLogsTable:    "main.team.logs_prior",
+	}
+	disabledState := persistentState{
+		OtelMetricsTable:    "main.team.metrics_prior",
+		OtelLogsTable:       "main.team.logs_prior",
+		OtelMetricsDisabled: true,
+		OtelLogsDisabled:    true,
+	}
+
+	type wantTuple struct {
+		metrics, logs       string
+		stateMetrics        string
+		stateLogs           string
+		stateMetricsDisable bool
+		stateLogsDisable    bool
+		stateMutated        bool
+	}
+
+	cases := []struct {
+		name        string
+		saved       persistentState
+		metricsFlag string
+		metricsSet  bool
+		logsFlag    string
+		logsSet     bool
+		want        wantTuple
+	}{
+		{
+			// Bare invocation, empty state: resolver itself emits empty
+			// tables — the bare-toggle metrics default is the caller's
+			// policy decision (runConfigOTELEnable applies it). Pure-
+			// resolver test asserts the resolver does NOT invent a table
+			// name on its own.
+			name:  "empty state, no flags: resolver emits empty tables (caller applies default)",
+			saved: emptyState,
+			want: wantTuple{
+				metrics:      "",
+				logs:         "",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "empty state, --metrics-table only → derives logs, persists metrics",
+			saved:       emptyState,
+			metricsFlag: "cat.s.m",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "cat.s.m",
+				logs:         "cat.s.m_otel_logs",
+				stateMetrics: "cat.s.m",
+				stateMutated: true,
+			},
+		},
+		{
+			name:        "empty state, both metrics and logs explicit → no derivation, both persisted",
+			saved:       emptyState,
+			metricsFlag: "cat.s.m",
+			metricsSet:  true,
+			logsFlag:    "cat.s.l",
+			logsSet:     true,
+			want: wantTuple{
+				metrics:      "cat.s.m",
+				logs:         "cat.s.l",
+				stateMetrics: "cat.s.m",
+				stateLogs:    "cat.s.l",
+				stateMutated: true,
+			},
+		},
+		{
+			name:  "populated state, no flags → state values preserved, no mutation",
+			saved: populatedState,
+			want: wantTuple{
+				metrics:      "main.team.metrics_prior",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_prior",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "populated state, --metrics-table same as state → no mutation",
+			saved:       populatedState,
+			metricsFlag: "main.team.metrics_prior",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "main.team.metrics_prior",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_prior",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "populated state, --metrics-table changes value → mutation",
+			saved:       populatedState,
+			metricsFlag: "main.team.metrics_new",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "main.team.metrics_new",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_new",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: true,
+			},
+		},
+		{
+			// `config otel disable` previously stuck the disable bits;
+			// `config otel enable` (even with no flags) must clear them
+			// so the next session emits the [otel] section. This is the
+			// round-trip that the two-store model requires.
+			name:  "disabled state, no flags → tables preserved, Disabled bits cleared",
+			saved: disabledState,
+			want: wantTuple{
+				metrics:             "main.team.metrics_prior",
+				logs:                "main.team.logs_prior",
+				stateMetrics:        "main.team.metrics_prior",
+				stateLogs:           "main.team.logs_prior",
+				stateMetricsDisable: false,
+				stateLogsDisable:    false,
+				stateMutated:        true,
+			},
+		},
+		{
+			// Empty-state with --logs-table only: logs flag wins, metrics
+			// stays empty (the resolver does NOT apply the bare-toggle
+			// metrics default — that's the caller's job).
+			name:    "empty state, --logs-table only → logs persisted, metrics still empty",
+			saved:   emptyState,
+			logsFlag: "cat.s.l",
+			logsSet: true,
+			want: wantTuple{
+				metrics:      "",
+				logs:         "cat.s.l",
+				stateMetrics: "",
+				stateLogs:    "cat.s.l",
+				stateMutated: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := resolveConfigOTEL(tc.saved,
+				tc.metricsFlag, tc.metricsSet,
+				tc.logsFlag, tc.logsSet,
+			)
+
+			if res.MetricsTable != tc.want.metrics {
+				t.Errorf("MetricsTable: got %q, want %q", res.MetricsTable, tc.want.metrics)
+			}
+			if res.LogsTable != tc.want.logs {
+				t.Errorf("LogsTable: got %q, want %q", res.LogsTable, tc.want.logs)
+			}
+			if got, want := res.NewState.OtelMetricsTable, tc.want.stateMetrics; got != want {
+				t.Errorf("NewState.OtelMetricsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelLogsTable, tc.want.stateLogs; got != want {
+				t.Errorf("NewState.OtelLogsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelMetricsDisabled, tc.want.stateMetricsDisable; got != want {
+				t.Errorf("NewState.OtelMetricsDisabled: got %v, want %v", got, want)
+			}
+			if got, want := res.NewState.OtelLogsDisabled, tc.want.stateLogsDisable; got != want {
+				t.Errorf("NewState.OtelLogsDisabled: got %v, want %v", got, want)
+			}
+			if res.StateMutated != tc.want.stateMutated {
+				t.Errorf("StateMutated: got %v, want %v", res.StateMutated, tc.want.stateMutated)
+			}
+		})
+	}
+}
+
+// TestResolveConfigOTEL_OnlyExplicitFlagsPersist asserts the sentinel-guard
+// invariant: a value derived purely from saved state (no explicit flag)
+// must NOT be re-persisted with a "mutated" flag. This is the issue-#149
+// footgun that bit databricks-claude — assert it here so the codex
+// resolver doesn't grow the same bug class.
+func TestResolveConfigOTEL_OnlyExplicitFlagsPersist(t *testing.T) {
+	saved := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+	}
+	res := resolveConfigOTEL(saved,
+		"", false, // no metrics-table flag — derived from state
+		"", false,
+	)
+	if res.StateMutated {
+		t.Errorf("StateMutated must be false when no explicit flag was passed; resolver should not echo state-derived values back to state. NewState=%+v", res.NewState)
+	}
+}
+
+// TestConfigOTELEnableDisableRoundTrip exercises the full enable→disable→
+// re-enable round trip end-to-end via the resolver, asserting the
+// state-preservation invariant the two-store model promises:
+//
+//  1. enable persists tables.
+//  2. disable sets Disabled bits but leaves table names intact.
+//  3. re-enable (no flags) clears the Disabled bits and resurfaces the
+//     same tables — no re-typing required.
+func TestConfigOTELEnableDisableRoundTrip(t *testing.T) {
+	// Step 1: empty state + explicit tables → enabled with both persisted.
+	step1 := resolveConfigOTEL(persistentState{},
+		"main.team.m", true,
+		"main.team.l", true,
+	)
+	if step1.NewState.OtelMetricsTable != "main.team.m" || step1.NewState.OtelLogsTable != "main.team.l" {
+		t.Fatalf("step 1 state not persisted as expected: %+v", step1.NewState)
+	}
+
+	// Step 2: simulate `config otel disable` — both Disabled bits true,
+	// tables preserved.
+	disabled := step1.NewState
+	disabled.OtelMetricsDisabled = true
+	disabled.OtelLogsDisabled = true
+
+	// resolveOtel (the SESSION reader) sees both signals off.
+	if otel, m, l := resolveOtel(disabled); otel || m != "" || l != "" {
+		t.Errorf("after disable, session resolveOtel must see signals off; got otel=%v metrics=%q logs=%q", otel, m, l)
+	}
+
+	// Step 3: re-enable with no flags. Resolver clears Disabled bits and
+	// re-emits the same tables.
+	step3 := resolveConfigOTEL(disabled, "", false, "", false)
+	if step3.MetricsTable != "main.team.m" {
+		t.Errorf("re-enable MetricsTable: got %q, want %q (round-trip preserved)", step3.MetricsTable, "main.team.m")
+	}
+	if step3.LogsTable != "main.team.l" {
+		t.Errorf("re-enable LogsTable: got %q, want %q (round-trip preserved)", step3.LogsTable, "main.team.l")
+	}
+	if step3.NewState.OtelMetricsDisabled || step3.NewState.OtelLogsDisabled {
+		t.Errorf("re-enable must clear Disabled bits; got %+v", step3.NewState)
+	}
+	if !step3.StateMutated {
+		t.Error("re-enable must mark state mutated (Disabled bits flipping false counts as a mutation)")
+	}
+}
+
+// TestConfigCommandHelpRendersSubcommandNames is a light smoke check on
+// the help layer: the configCommand Long body must mention each surface
+// the README documents (otel enable/disable, show).
+func TestConfigCommandHelpRendersSubcommandNames(t *testing.T) {
+	out := configCommand.Long
+	for _, want := range []string{"otel enable", "otel disable", "show"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("configCommand.Long missing %q; help text drifted from runner surface", want)
+		}
+	}
+}
+
+// flagNameSetForConfig returns the set of long-flag names declared on a
+// tree node (Persistent ++ Flags). Local helper so cli_config_test.go has
+// no dependency on test helpers in main_test.go beyond what's needed.
+func flagNameSetForConfig(c cmd.Command) map[string]bool {
+	out := make(map[string]bool)
+	for _, f := range c.AllFlags() {
+		out[f.Name] = true
+	}
+	return out
+}
+
+// assertConfigFlagSetEqual fails if the actual flag set declared on c
+// differs from the expected slice. Bidirectional: extra flags on either
+// side surface as failures.
+func assertConfigFlagSetEqual(t *testing.T, label string, c cmd.Command, want []string) {
+	t.Helper()
+	got := flagNameSetForConfig(c)
+	wantSet := make(map[string]bool, len(want))
+	for _, w := range want {
+		wantSet[w] = true
+		if !got[w] {
+			t.Errorf("%s should declare --%s but does not (runner consumes it; tree must too)", label, w)
+		}
+	}
+	for n := range got {
+		if !wantSet[n] {
+			t.Errorf("%s declares --%s but its runner does not consume it (dead declaration; remove from tree or wire to runner)", label, n)
+		}
+	}
+}

--- a/commands.go
+++ b/commands.go
@@ -21,11 +21,13 @@ import (
 // TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
 // drift apart — the tree is the single source of truth.
 //
-// #86 migrates only the *root* command. config / hooks / serve continue
-// to live as root flags + their existing dispatch in main.go; their
-// migration onto Subcommands is tracked in #87/#88/#89. --profile and
-// --port are already declared as Persistent so subcommand inheritance
-// works out of the box once those migrations land.
+// #86 migrated the *root* command. #88 lifts the hooks lifecycle flags
+// (--install-hooks / --uninstall-hooks / --headless-ensure) onto a
+// `hooks` subcommand; the legacy root-flag spellings are removed and any
+// invocation that used them now errors (or, if completely unrecognised,
+// is forwarded to codex). --profile and --port live on Persistent so
+// subcommand inheritance works for the new tree. config / serve are
+// still tracked under #87/#89.
 var rootCommand = cmd.Command{
 	Name:  "databricks-codex",
 	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
@@ -82,18 +84,16 @@ var rootCommand = cmd.Command{
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 		{Name: "headless", Description: "Start proxy without launching codex (for IDE extensions or hooks)"},
 		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true, Default: "30m"},
-		{Name: "install-hooks", Description: "Install SessionStart hook into ~/.codex/hooks.json"},
-		{Name: "uninstall-hooks", Description: "Remove databricks-codex hooks from ~/.codex/hooks.json"},
-		{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
 	// Subcommands declared on the root. completion and update dispatch
-	// from main.go directly today; config/hooks/serve children are not
-	// yet on the tree (they're still root flags — see #87/#88/#89).
+	// from main.go directly. #88 adds `hooks` (install/uninstall/
+	// session-start); config/serve are still tracked under #87/#89.
 	Subcommands: []cmd.Command{
 		completionCommand,
 		updateCommand,
+		hooksCommand,
 	},
 }
 
@@ -117,3 +117,135 @@ var updateCommand = cmd.Command{
 	Name:  "update",
 	Short: "Check for a newer release and print upgrade instructions",
 }
+
+// hooksCommand declares the `hooks` subcommand tree introduced in #88.
+// Consolidates the 3 hooks-lifecycle root flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure) under a discoverable subcommand.
+// install/uninstall manage the SessionStart entries in ~/.codex/hooks.json;
+// session-start is hook-invoked refcount-managed proxy lifecycle internal
+// (formerly --headless-ensure).
+//
+// Tree shape:
+//
+//	hooks
+//	├── install        [--profile P] [--port N]
+//	├── uninstall
+//	└── session-start  [--port N]   (hook-invoked internal)
+//
+// The hook-install logic (installHooks/uninstallHooks in hooks.go) and the
+// proxy-ensure logic (headlessEnsure) are unchanged behaviorally — they
+// move behind tree commands. The detector that matches "databricks-codex
+// --headless"-prefixed entries continues to recognise hooks installed by
+// the legacy flag spellings, so a re-install replaces them cleanly with
+// the new "databricks-codex hooks session-start" command line.
+var hooksCommand = cmd.Command{
+	Name:  "hooks",
+	Short: "Session-hook deployment mode: install/uninstall + lifecycle internals",
+	Long:  hooksHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "install",
+			Short: "Install SessionStart hook into ~/.codex/hooks.json",
+			Long:  hooksInstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "uninstall",
+			Short: "Remove databricks-codex hooks from ~/.codex/hooks.json",
+			Long:  hooksUninstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-start",
+			Short: "Start proxy if not running (invoked by the SessionStart hook — internal)",
+			Long:  hooksSessionStartHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49154)", TakesArg: true, StateKey: "port", Default: "49154"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+const hooksHelpTemplate = `Usage: databricks-codex hooks <subcommand> [flags]
+
+Session-hook deployment mode for the OpenAI Codex CLI. Installs hook
+entries into ~/.codex/hooks.json that spin a refcount-managed proxy up on
+SessionStart — making 'databricks-codex' auto-launch with every codex
+session without a long-lived daemon.
+
+Subcommands:
+  install        Install the SessionStart hook into ~/.codex/hooks.json
+                 (idempotent). Also flips [features] hooks = true in
+                 ~/.codex/config.toml so codex actually reads the file.
+  uninstall      Remove databricks-codex hooks from
+                 ~/.codex/hooks.json. Tolerates "not installed".
+  session-start  Hook-invoked internal: starts the proxy if it isn't
+                 already running. Called by the SessionStart hook JSON
+                 written by 'hooks install'. Not intended to be invoked
+                 directly.
+
+Run 'databricks-codex hooks <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-codex hooks install
+
+  # Remove hooks (e.g. when switching back to the manual proxy mode):
+  databricks-codex hooks uninstall
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const hooksInstallHelpTemplate = `Usage: databricks-codex hooks install [flags]
+
+Install the SessionStart hook into ~/.codex/hooks.json so that every
+codex session auto-launches a refcount-managed databricks-codex proxy
+in the background. Idempotent — safe to re-run after upgrades.
+
+Also ensures [features] hooks = true in ~/.codex/config.toml; without
+that flag codex does not read hooks.json at all.
+
+Generated hook JSON:
+  SessionStart → "databricks-codex hooks session-start"
+
+Flags:
+  --help, -h    Show this help message
+`
+
+const hooksUninstallHelpTemplate = `Usage: databricks-codex hooks uninstall [flags]
+
+Remove databricks-codex hook entries from ~/.codex/hooks.json. Other
+user-authored hooks survive byte-identical. Also removes the
+[features] hooks = true line databricks-codex installed; legacy
+codex_hooks = true (if present) is left untouched.
+
+If hooks.json doesn't exist, this is a no-op.
+
+Flags:
+  --help, -h    Show this help message
+`
+
+const hooksSessionStartHelpTemplate = `Usage: databricks-codex hooks session-start [flags]
+
+Hook-invoked internal: probes the local proxy on the configured port
+and, if absent, starts a detached headless databricks-codex process
+that exits via idle timeout. Replaces the legacy --headless-ensure
+flag. Not intended for direct invocation — the SessionStart hook
+JSON written by 'hooks install' calls this command.
+
+MUST remain fast and fail-fast: no interactive auth flow. If the user
+hasn't run 'databricks auth login' yet, this command exits 0 silently
+so the codex session is not blocked on a hook timeout.
+
+Flags:
+  --port int    Override saved port (default: saved state > 49154)
+  --help, -h    Show this help message
+`

--- a/commands.go
+++ b/commands.go
@@ -21,24 +21,23 @@ import (
 // TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
 // drift apart — the tree is the single source of truth.
 //
-// #86 migrated the *root* command. #88 lifts the hooks lifecycle flags
-// (--install-hooks / --uninstall-hooks / --headless-ensure) onto a
-// `hooks` subcommand; the legacy root-flag spellings are removed and any
-// invocation that used them now errors (or, if completely unrecognised,
-// is forwarded to codex). --profile and --port live on Persistent so
-// subcommand inheritance works for the new tree. config / serve are
-// still tracked under #87/#89.
+// #86 migrated the root command onto the tree. #87 lifts the persistent-config
+// editor (the legacy --otel*/--print-env root flags) onto a discoverable
+// `config` subcommand; #88 lifts the hooks lifecycle flags
+// (--install-hooks / --uninstall-hooks / --headless-ensure) onto a `hooks`
+// subcommand. Both sets of legacy root-flag spellings are GONE in this
+// revision. serve is still tracked under #89. --profile and --port live on
+// Persistent so subcommand inheritance works for the migrated children.
 var rootCommand = cmd.Command{
 	Name:  "databricks-codex",
 	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
 
 	// Persistent flags are inherited by every subcommand once those
-	// commands migrate onto the tree (#87/#88/#89). For now, declaring
-	// them here is a no-op for the existing inline-handled root flags
-	// but ensures the tree is shaped correctly for the follow-up. Both
-	// flags also feed the resolution chain in main.go today; the
-	// StateKey/EnvVar/Default fields below document that behavior so
-	// later sub-issues can derive the chain from this declaration.
+	// commands migrate onto the tree (#89). Each migrated leaf
+	// (today: config + hooks children) re-declares --profile / --port
+	// locally where it consumes them — internal/cmd's parser does not
+	// yet walk ancestors, so this is the same shape as databricks-claude's
+	// configCommand leaves.
 	Persistent: []cmd.FlagDef{
 		{
 			Name:        "profile",
@@ -60,22 +59,14 @@ var rootCommand = cmd.Command{
 	},
 
 	// Order matches the legacy flagDefs slice so the bash/zsh/fish
-	// completion output stays byte-identical with the pre-tree binary.
-	// The two flags ("profile" and "port") that previously appeared in
-	// the flagDefs slice now live under Persistent (which renders first
-	// in AllFlags), so completion ordering needs to mirror that — see
-	// completion_flags.go where flagDefs is rebuilt from rootCommand.
+	// completion output stays byte-identical with the pre-tree binary
+	// for the flags that survived #87/#88. The migrated OTEL/--print-env
+	// and hooks-lifecycle flags are gone from BOTH this slice and
+	// completion_flags.go's `order` — that is the breaking surface change.
 	Flags: []cmd.FlagDef{
 		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
 		{Name: "version", Description: "Print version and exit"},
 		{Name: "help", Short: "h", Description: "Show help message"},
-		{Name: "print-env", Description: "Print resolved configuration (token redacted) and exit"},
-		{Name: "otel", Description: "Enable OpenTelemetry export (metrics + logs)"},
-		{Name: "no-otel", Description: "Disable OpenTelemetry for this session (saved tables preserved)"},
-		{Name: "no-otel-metrics", Description: "Disable metrics for this session (saved table preserved)"},
-		{Name: "no-otel-logs", Description: "Disable logs for this session (saved table preserved)"},
-		{Name: "otel-metrics-table", Description: "Unity Catalog table for OTel metrics (cat.schema.table)", TakesArg: true, StateKey: "otel_metrics_table"},
-		{Name: "otel-logs-table", Description: "Unity Catalog table for OTel logs (cat.schema.table)", TakesArg: true, StateKey: "otel_logs_table"},
 		{Name: "model", Description: "Model to use (default: databricks-claude-sonnet-4-5)", TakesArg: true, StateKey: "model"},
 		{Name: "upstream", Description: "Override upstream codex binary path", TakesArg: true, Completer: "__files"},
 		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
@@ -88,11 +79,14 @@ var rootCommand = cmd.Command{
 	},
 
 	// Subcommands declared on the root. completion and update dispatch
-	// from main.go directly. #88 adds `hooks` (install/uninstall/
-	// session-start); config/serve are still tracked under #87/#89.
+	// from main.go directly. config (added in #87) carries its own
+	// dispatcher in cli_config.go. hooks (added in #88) carries its own
+	// dispatcher in cli_hooks.go. serve remains as root flags for now —
+	// see #89.
 	Subcommands: []cmd.Command{
 		completionCommand,
 		updateCommand,
+		configCommand,
 		hooksCommand,
 	},
 }
@@ -116,6 +110,74 @@ var completionCommand = cmd.Command{
 var updateCommand = cmd.Command{
 	Name:  "update",
 	Short: "Check for a newer release and print upgrade instructions",
+}
+
+// configCommand declares the `config` subcommand tree introduced in #87.
+// Consolidates the persistent-config root flags (--otel, --no-otel,
+// --no-otel-metrics, --no-otel-logs, --otel-metrics-table,
+// --otel-logs-table, --print-env) into a discoverable tree. Storage
+// semantics — state-file table preferences preserved across `config otel
+// disable`, ~/.codex/config.toml [otel] section *removal* (not just
+// skip-the-write) when both signals are off — are unchanged; this is a
+// pure surface reshape.
+//
+// Tree shape:
+//
+//	config
+//	├── otel
+//	│   ├── enable     [--metrics-table T] [--logs-table T]
+//	│   └── disable    [--metrics] [--logs]      (no flags = both signals)
+//	└── show           (was --print-env)
+//
+// Codex's surface is smaller than databricks-claude's: no `config write`
+// (codex has no settings.json env block — config.toml is patched at
+// session start by the proxy lifecycle, not by a one-shot bootstrap), no
+// `config websearch` (codex has no local websearch fulfilment), no
+// traces signal (codex's tomlconfig manages logs + metrics exporters
+// only).
+var configCommand = cmd.Command{
+	Name:  "config",
+	Short: "Persistent config editor (otel, show)",
+	Long:  configHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "otel",
+			Short: "Toggle OpenTelemetry signals (enable|disable)",
+			Long:  configOtelHelpTemplate,
+			Subcommands: []cmd.Command{
+				{
+					Name:  "enable",
+					Short: "Enable OTEL — persists table preferences to state for the next codex session",
+					Long:  configOtelEnableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics-table", Description: "Unity Catalog table for OTEL metrics (cat.schema.table)", TakesArg: true, StateKey: "otel_metrics_table"},
+						{Name: "logs-table", Description: "Unity Catalog table for OTEL logs (cat.schema.table)", TakesArg: true, StateKey: "otel_logs_table"},
+						{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+				{
+					Name:  "disable",
+					Short: "Disable OTEL — clears the [otel] section from ~/.codex/config.toml on the next session start (state file preserved)",
+					Long:  configOtelDisableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics", Description: "Disable only OTEL metrics (other signals untouched)"},
+						{Name: "logs", Description: "Disable only OTEL logs"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+			},
+		},
+		{
+			Name:  "show",
+			Short: "Print resolved configuration (was --print-env)",
+			Long:  configShowHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
 }
 
 // hooksCommand declares the `hooks` subcommand tree introduced in #88.
@@ -170,6 +232,130 @@ var hooksCommand = cmd.Command{
 		},
 	},
 }
+
+const configHelpTemplate = `Usage: databricks-codex config <subcommand> [flags]
+
+Persistent config editor. Mutates ~/.codex/.databricks-codex.json (state file)
+to record table preferences that the proxy lifecycle reads at the next codex
+session start. ~/.codex/config.toml is NOT touched by config.* commands —
+config.toml is owned by the proxy lifecycle and is rewritten when codex
+launches.
+
+Subcommands:
+  otel enable [flags]   Persist OTEL table preferences and (next session)
+                        emit the [otel] section in config.toml.
+  otel disable [flags]  Mark OTEL signals as off for the next session. The
+                        proxy lifecycle removes the [otel] section from
+                        config.toml on its next start. State-file table
+                        preferences are PRESERVED so a future
+                        'config otel enable' restores them.
+  show [flags]          Print the resolved configuration (token redacted).
+                        Read-only — no writes.
+
+Run 'databricks-codex config <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # Enable OTEL with explicit metrics + logs tables:
+  databricks-codex config otel enable \
+    --metrics-table main.codex_telemetry.codex_otel_metrics \
+    --logs-table   main.codex_telemetry.codex_otel_logs
+
+  # Disable just metrics (logs still routed if previously enabled):
+  databricks-codex config otel disable --metrics
+
+  # Disable all signals:
+  databricks-codex config otel disable
+
+  # Diagnostic dump:
+  databricks-codex config show
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const configOtelHelpTemplate = `Usage: databricks-codex config otel <enable|disable> [flags]
+
+Toggle OpenTelemetry signal export for the wrapped codex session. Storage:
+  - Tables (metrics/logs) are persisted to ~/.codex/.databricks-codex.json
+  - The [otel] section in ~/.codex/config.toml is written or removed by the
+    proxy lifecycle the next time codex starts (this command does not edit
+    config.toml directly).
+
+'config otel disable' marks signals off in the state file but PRESERVES the
+table-name preferences so a subsequent 'config otel enable' can restore them
+without re-typing.
+
+Subcommands:
+  enable    Persist OTEL table preferences (see 'config otel enable --help').
+  disable   Mark OTEL signals off for the next session (see 'config otel disable --help').
+`
+
+const configOtelEnableHelpTemplate = `Usage: databricks-codex config otel enable [flags]
+
+Enable OTEL — persists the resolved table names to ~/.codex/.databricks-codex.json
+so the proxy lifecycle emits the [otel] section in ~/.codex/config.toml the
+next time codex launches.
+
+Resolution chain per signal: explicit flag > state file > derive (logs from
+metrics) > unset. With no table flags and an empty state file, --metrics-table
+defaults to 'main.codex_telemetry.codex_otel_metrics' (matching the legacy
+'--otel' bare-toggle behavior).
+
+Flags:
+  --metrics-table string   Unity Catalog table for OTEL metrics (cat.schema.table)
+  --logs-table string      Unity Catalog table for OTEL logs   (cat.schema.table)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --help, -h               Show this help message
+
+Examples:
+  # Enable with custom metrics + logs tables:
+  databricks-codex config otel enable \
+    --metrics-table main.telemetry.codex_otel_metrics \
+    --logs-table   main.telemetry.codex_otel_logs
+
+  # Enable with default tables (logs derived from metrics):
+  databricks-codex config otel enable
+`
+
+const configOtelDisableHelpTemplate = `Usage: databricks-codex config otel disable [flags]
+
+Mark OTEL signals off in the state file. The proxy lifecycle clears the
+[otel] section from ~/.codex/config.toml on its next start. State-file table
+preferences are PRESERVED — a subsequent 'config otel enable' restores them.
+With no flags, BOTH signals are disabled (equivalent to the legacy --no-otel).
+
+Flags:
+  --metrics    Disable only OTEL metrics (logs untouched)
+  --logs       Disable only OTEL logs
+  --help, -h   Show this help message
+
+Examples:
+  # Disable both signals:
+  databricks-codex config otel disable
+
+  # Disable just metrics:
+  databricks-codex config otel disable --metrics
+
+  # Disable just logs:
+  databricks-codex config otel disable --logs
+`
+
+const configShowHelpTemplate = `Usage: databricks-codex config show [flags]
+
+Print the resolved configuration (token redacted) and exit. Read-only —
+zero writes to the state file or config.toml. Replaces the legacy
+--print-env flag.
+
+Resolves: profile, model, Databricks workspace host, AI Gateway URL,
+auth token (redacted), the persisted OTEL UC tables, and the discovered
+codex binary path.
+
+Flags:
+  --profile string   Databricks CLI profile (default: state > DEFAULT)
+  --help, -h         Show this help message
+`
 
 const hooksHelpTemplate = `Usage: databricks-codex hooks <subcommand> [flags]
 

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// rootCommand is the source-of-truth declaration for the databricks-codex
+// CLI. It drives:
+//   - parseArgs → knownFlags (the set of "--flag" names the binary owns;
+//     anything else is forwarded transparently to the wrapped codex binary).
+//   - flagDefs (in completion_flags.go) → the bash/zsh/fish completion
+//     scripts (fed via pkg/completion).
+//
+// Adding a new root flag requires three edits:
+//  1. Append a FlagDef to Flags (or Persistent for inherited flags) here.
+//  2. Add a case to the switch in parseArgs (main.go) that wires the flag
+//     into the Args struct.
+//  3. Add the matching field to the Args struct.
+//
+// The parity tests in main_test.go (TestRootTreeFlagsAreParseRecognised,
+// TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
+// drift apart — the tree is the single source of truth.
+//
+// #86 migrates only the *root* command. config / hooks / serve continue
+// to live as root flags + their existing dispatch in main.go; their
+// migration onto Subcommands is tracked in #87/#88/#89. --profile and
+// --port are already declared as Persistent so subcommand inheritance
+// works out of the box once those migrations land.
+var rootCommand = cmd.Command{
+	Name:  "databricks-codex",
+	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
+
+	// Persistent flags are inherited by every subcommand once those
+	// commands migrate onto the tree (#87/#88/#89). For now, declaring
+	// them here is a no-op for the existing inline-handled root flags
+	// but ensures the tree is shaped correctly for the follow-up. Both
+	// flags also feed the resolution chain in main.go today; the
+	// StateKey/EnvVar/Default fields below document that behavior so
+	// later sub-issues can derive the chain from this declaration.
+	Persistent: []cmd.FlagDef{
+		{
+			Name:        "profile",
+			Description: "Databricks CLI profile (default: DEFAULT)",
+			TakesArg:    true,
+			Completer:   "__databricks_profiles",
+			StateKey:    "profile",
+			EnvVar:      "DATABRICKS_CONFIG_PROFILE",
+			MDMKey:      "databricksProfile",
+			Default:     "DEFAULT",
+		},
+		{
+			Name:        "port",
+			Description: "Proxy listen port (default: 49154)",
+			TakesArg:    true,
+			StateKey:    "port",
+			Default:     "49154",
+		},
+	},
+
+	// Order matches the legacy flagDefs slice so the bash/zsh/fish
+	// completion output stays byte-identical with the pre-tree binary.
+	// The two flags ("profile" and "port") that previously appeared in
+	// the flagDefs slice now live under Persistent (which renders first
+	// in AllFlags), so completion ordering needs to mirror that — see
+	// completion_flags.go where flagDefs is rebuilt from rootCommand.
+	Flags: []cmd.FlagDef{
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "version", Description: "Print version and exit"},
+		{Name: "help", Short: "h", Description: "Show help message"},
+		{Name: "print-env", Description: "Print resolved configuration (token redacted) and exit"},
+		{Name: "otel", Description: "Enable OpenTelemetry export (metrics + logs)"},
+		{Name: "no-otel", Description: "Disable OpenTelemetry for this session (saved tables preserved)"},
+		{Name: "no-otel-metrics", Description: "Disable metrics for this session (saved table preserved)"},
+		{Name: "no-otel-logs", Description: "Disable logs for this session (saved table preserved)"},
+		{Name: "otel-metrics-table", Description: "Unity Catalog table for OTel metrics (cat.schema.table)", TakesArg: true, StateKey: "otel_metrics_table"},
+		{Name: "otel-logs-table", Description: "Unity Catalog table for OTel logs (cat.schema.table)", TakesArg: true, StateKey: "otel_logs_table"},
+		{Name: "model", Description: "Model to use (default: databricks-claude-sonnet-4-5)", TakesArg: true, StateKey: "model"},
+		{Name: "upstream", Description: "Override upstream codex binary path", TakesArg: true, Completer: "__files"},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "headless", Description: "Start proxy without launching codex (for IDE extensions or hooks)"},
+		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true, Default: "30m"},
+		{Name: "install-hooks", Description: "Install SessionStart hook into ~/.codex/hooks.json"},
+		{Name: "uninstall-hooks", Description: "Remove databricks-codex hooks from ~/.codex/hooks.json"},
+		{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+	},
+
+	// Subcommands declared on the root. completion and update dispatch
+	// from main.go directly today; config/hooks/serve children are not
+	// yet on the tree (they're still root flags — see #87/#88/#89).
+	Subcommands: []cmd.Command{
+		completionCommand,
+		updateCommand,
+	},
+}
+
+// completionCommand declares the `completion` subcommand and its three
+// shell-target children. Dispatch lives in main.go (calls completion.Run);
+// the tree exists so shell completion can offer "completion <TAB>" → bash
+// / zsh / fish, and so the help renderer has a node to describe.
+var completionCommand = cmd.Command{
+	Name:  "completion",
+	Short: "Generate shell completion scripts (bash, zsh, fish)",
+	Subcommands: []cmd.Command{
+		{Name: "bash", Short: "Generate bash completion script"},
+		{Name: "zsh", Short: "Generate zsh completion script"},
+		{Name: "fish", Short: "Generate fish completion script"},
+	},
+}
+
+// updateCommand declares the `update` subcommand. Dispatch lives in main.go
+// (calls updater.Check + prints upgrade instructions).
+var updateCommand = cmd.Command{
+	Name:  "update",
+	Short: "Check for a newer release and print upgrade instructions",
+}

--- a/commands.go
+++ b/commands.go
@@ -25,9 +25,10 @@ import (
 // editor (the legacy --otel*/--print-env root flags) onto a discoverable
 // `config` subcommand; #88 lifts the hooks lifecycle flags
 // (--install-hooks / --uninstall-hooks / --headless-ensure) onto a `hooks`
-// subcommand. Both sets of legacy root-flag spellings are GONE in this
-// revision. serve is still tracked under #89. --profile and --port live on
-// Persistent so subcommand inheritance works for the migrated children.
+// subcommand. #89 lifts the remaining session-mode root flags (--headless,
+// --idle-timeout) onto a `serve` subcommand. All three sets of legacy
+// root-flag spellings are GONE in this revision. --profile and --port live
+// on Persistent so subcommand inheritance works for the migrated children.
 var rootCommand = cmd.Command{
 	Name:  "databricks-codex",
 	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
@@ -60,9 +61,10 @@ var rootCommand = cmd.Command{
 
 	// Order matches the legacy flagDefs slice so the bash/zsh/fish
 	// completion output stays byte-identical with the pre-tree binary
-	// for the flags that survived #87/#88. The migrated OTEL/--print-env
-	// and hooks-lifecycle flags are gone from BOTH this slice and
-	// completion_flags.go's `order` — that is the breaking surface change.
+	// for the flags that survived #87/#88/#89. The migrated OTEL/--print-env,
+	// hooks-lifecycle, and session-mode flags are gone from BOTH this slice
+	// and completion_flags.go's `order` — that is the breaking surface
+	// change.
 	Flags: []cmd.FlagDef{
 		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
 		{Name: "version", Description: "Print version and exit"},
@@ -73,21 +75,20 @@ var rootCommand = cmd.Command{
 		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
 		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
-		{Name: "headless", Description: "Start proxy without launching codex (for IDE extensions or hooks)"},
-		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true, Default: "30m"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
 	// Subcommands declared on the root. completion and update dispatch
 	// from main.go directly. config (added in #87) carries its own
 	// dispatcher in cli_config.go. hooks (added in #88) carries its own
-	// dispatcher in cli_hooks.go. serve remains as root flags for now —
-	// see #89.
+	// dispatcher in hooks_cmd.go. serve (added in #89) carries its own
+	// dispatcher in serve_cmd.go.
 	Subcommands: []cmd.Command{
 		completionCommand,
 		updateCommand,
 		configCommand,
 		hooksCommand,
+		serveCommand,
 	},
 }
 
@@ -230,6 +231,46 @@ var hooksCommand = cmd.Command{
 				{Name: "help", Short: "h", Description: "Show help message"},
 			},
 		},
+	},
+}
+
+// serveCommand declares the `serve` subcommand introduced in #89.
+// Consolidates the legacy `--headless` and `--idle-timeout` root flags into
+// a discoverable subcommand. Mirrors databricks-claude #174's `serve
+// --session-mode` entrypoint with a deliberately smaller scope: codex has
+// no daemon mode (no LaunchAgent/Service equivalent), so install/uninstall/
+// status sub-subcommands are deferred.
+//
+// Tree shape:
+//
+//	serve   [--idle-timeout D] [--profile P] [--port N] [--model M]
+//	        [--upstream U] [--log-file F] [--verbose|-v]
+//	        [--proxy-api-key K] [--tls-cert C] [--tls-key K]
+//	        [--no-update-check]
+//
+// Behavior is byte-identical with the deleted `databricks-codex --headless`
+// path: the runner constructs the same Args struct that parseArgs used to,
+// sets Headless=true, and dispatches into the shared runProxyMode launcher.
+// The hook-spawn path (headlessEnsure → headless.Ensure) is updated to
+// invoke `databricks-codex serve --port=N` instead of the removed
+// `--headless --port=N` so the SessionStart hook keeps working.
+var serveCommand = cmd.Command{
+	Name:  "serve",
+	Short: "Run the proxy in headless mode (consolidates --headless / --idle-timeout)",
+	Long:  serveHelpTemplate,
+	Flags: []cmd.FlagDef{
+		{Name: "idle-timeout", Description: "Idle timeout (default: 30m; 0 disables; e.g. 30s, 5m, 1h)", TakesArg: true, Default: "30m"},
+		{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+		{Name: "port", Description: "Proxy listen port (default: saved state > 49154)", TakesArg: true, StateKey: "port", Default: "49154"},
+		{Name: "model", Description: "Model to use (saved for future sessions)", TakesArg: true, StateKey: "model"},
+		{Name: "upstream", Description: "Override the AI Gateway URL (default: auto-discovered)", TakesArg: true},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+		{Name: "help", Short: "h", Description: "Show help message"},
 	},
 }
 
@@ -431,7 +472,56 @@ MUST remain fast and fail-fast: no interactive auth flow. If the user
 hasn't run 'databricks auth login' yet, this command exits 0 silently
 so the codex session is not blocked on a hook timeout.
 
+Internally spawns 'databricks-codex serve --port=N' (the #89 replacement
+for the deleted '--headless' root flag).
+
 Flags:
   --port int    Override saved port (default: saved state > 49154)
   --help, -h    Show this help message
+`
+
+const serveHelpTemplate = `Usage: databricks-codex serve [flags]
+
+Run the proxy in headless mode without launching codex. Replaces the
+legacy '--headless' and '--idle-timeout' root flags (#89) with a
+discoverable subcommand. Behavior is byte-identical with the removed
+flags — the hooks SessionStart entry and IDE extensions can call this
+directly to bring the proxy up and read PROXY_URL=... from stdout.
+
+Use this when:
+  - An IDE extension needs the proxy running but doesn't want a child
+    codex process. Read PROXY_URL=... from stdout, point your client
+    at it, then SIGTERM (or POST /shutdown) when done.
+  - Bringing up the proxy from a SessionStart hook. 'hooks install'
+    wires this for you under the hood.
+
+The proxy exits when:
+  - SIGINT or SIGTERM is received.
+  - POST /shutdown is hit on the proxy URL.
+  - --idle-timeout elapses with zero in-flight requests (default 30m;
+    0 disables idle shutdown).
+
+Flags:
+  --idle-timeout duration  Idle timeout (default 30m, 0 disables; e.g. 30s, 5m, 1h)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy listen port (default: state > 49154)
+  --model string           Model name (saved for future sessions)
+  --upstream string        Override the AI Gateway URL (default: auto-discovered)
+  --log-file string        Write debug logs to file (combinable with --verbose)
+  --verbose, -v            Enable debug logging to stderr
+  --proxy-api-key string   Require this API key on all proxy requests
+  --tls-cert string        TLS certificate file (requires --tls-key)
+  --tls-key string         TLS private key file (requires --tls-cert)
+  --no-update-check        Skip the automatic update check on startup
+  --help, -h               Show this help message
+
+Examples:
+  # Start the proxy with the default 30-minute idle timeout:
+  databricks-codex serve
+
+  # Start with a 5-minute idle timeout (test/CI scenarios):
+  databricks-codex serve --idle-timeout 5m
+
+  # Start with idle shutdown disabled (long-running IDE sessions):
+  databricks-codex serve --idle-timeout 0
 `

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -43,9 +43,6 @@ var flagDefs = func() []completion.FlagDef {
 		"port",
 		"headless",
 		"idle-timeout",
-		"install-hooks",
-		"uninstall-hooks",
-		"headless-ensure",
 		"no-update-check",
 	}
 	byName := map[string]completion.FlagDef{}
@@ -68,3 +65,11 @@ var flagDefs = func() []completion.FlagDef {
 // directly from rootCommand so it can never drift from the tree — the tree
 // is the source of truth for which flags the binary recognises.
 var knownFlags = rootCommand.KnownFlags()
+
+// knownSubcommands is the recursive shell-completion subcommand tree fed
+// to pkg/completion so `databricks-codex <TAB>` offers completion / update
+// / hooks, and `databricks-codex hooks <TAB>` offers install / uninstall
+// / session-start. #88 lifts this from rootCommand alongside the dep bump
+// to databricks-claude v1.0.2 (which exports SubcommandDef); see the
+// doc-comment in internal/cmd/cmd.go for the prior #86 omission.
+var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -27,13 +27,6 @@ var flagDefs = func() []completion.FlagDef {
 		"verbose",
 		"version",
 		"help",
-		"print-env",
-		"otel",
-		"no-otel",
-		"no-otel-metrics",
-		"no-otel-logs",
-		"otel-metrics-table",
-		"otel-logs-table",
 		"model",
 		"upstream",
 		"log-file",
@@ -68,8 +61,10 @@ var knownFlags = rootCommand.KnownFlags()
 
 // knownSubcommands is the recursive shell-completion subcommand tree fed
 // to pkg/completion so `databricks-codex <TAB>` offers completion / update
-// / hooks, and `databricks-codex hooks <TAB>` offers install / uninstall
-// / session-start. #88 lifts this from rootCommand alongside the dep bump
-// to databricks-claude v1.0.2 (which exports SubcommandDef); see the
-// doc-comment in internal/cmd/cmd.go for the prior #86 omission.
+// / config / hooks, and `databricks-codex hooks <TAB>` offers install /
+// uninstall / session-start, `databricks-codex config <TAB>` offers otel
+// / show, etc. #87 introduced this wire-up alongside the dep bump to
+// databricks-claude v1.0.2 (which exports SubcommandDef); #88 adds the
+// hooks branch. See the doc-comment in internal/cmd/cmd.go for the prior
+// #86 omission.
 var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -2,49 +2,69 @@ package main
 
 import "github.com/IceRhymers/databricks-claude/pkg/completion"
 
-// flagDefs is the authoritative list of flags owned by databricks-codex.
-// Everything not listed here is forwarded transparently to the codex binary.
+// flagDefs is the ordered list of root flags fed to pkg/completion for
+// shell-script generation. Order is curated here (not implied by the tree)
+// because bash/zsh/fish completion output is order-sensitive — preserving
+// byte-equivalence with the pre-tree binary requires the original ordering
+// (--profile first, --port between --tls-key and --headless, etc.). Each
+// entry is derived from rootCommand so the tree remains the single source
+// of truth for which flags exist and what their descriptions / completers /
+// arg semantics are.
 //
-// Rules:
-//   - TakesArg: true  → the next token is consumed as the flag's value
-//   - TakesArg: false → the flag is a boolean toggle
-//   - Completer: "__databricks_profiles" → completes from ~/.databrickscfg sections
-//   - Completer: "__files"              → completes with local file paths
-//   - Short: "x"                        → also accepts -x as a short alias
-var flagDefs = []completion.FlagDef{
-	{Name: "profile", Description: "Databricks CLI profile (default: DEFAULT)", TakesArg: true, Completer: "__databricks_profiles"},
-	{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
-	{Name: "version", Description: "Print version and exit"},
-	{Name: "help", Short: "h", Description: "Show help message"},
-	{Name: "print-env", Description: "Print resolved configuration (token redacted) and exit"},
-	{Name: "otel", Description: "Enable OpenTelemetry export (metrics + logs)"},
-	{Name: "no-otel", Description: "Disable OpenTelemetry for this session (saved tables preserved)"},
-	{Name: "no-otel-metrics", Description: "Disable metrics for this session (saved table preserved)"},
-	{Name: "no-otel-logs", Description: "Disable logs for this session (saved table preserved)"},
-	{Name: "otel-metrics-table", Description: "Unity Catalog table for OTel metrics (cat.schema.table)", TakesArg: true},
-	{Name: "otel-logs-table", Description: "Unity Catalog table for OTel logs (cat.schema.table)", TakesArg: true},
-	{Name: "model", Description: "Model to use (default: databricks-claude-sonnet-4-5)", TakesArg: true},
-	{Name: "upstream", Description: "Override upstream codex binary path", TakesArg: true, Completer: "__files"},
-	{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
-	{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
-	{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
-	{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
-	{Name: "port", Description: "Proxy listen port (default: 49154)", TakesArg: true},
-	{Name: "headless", Description: "Start proxy without launching codex (for IDE extensions or hooks)"},
-	{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true},
-	{Name: "install-hooks", Description: "Install SessionStart hook into ~/.codex/hooks.json"},
-	{Name: "uninstall-hooks", Description: "Remove databricks-codex hooks from ~/.codex/hooks.json"},
-	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
-	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
-}
+// Adding a new root flag requires:
+//  1. Append a FlagDef to rootCommand.Flags (or .Persistent) in commands.go.
+//  2. Insert the new flag's name into the order slice below at the desired
+//     position in the completion output.
+// The init-time panic and the parity tests in main_test.go fail loudly if
+// step 2 is forgotten or if a name in `order` doesn't appear on rootCommand.
+var flagDefs = func() []completion.FlagDef {
+	// Original flagDefs ordering, preserved verbatim for byte-equivalent
+	// completion script generation. Two flags now live on rootCommand.Persistent
+	// (--profile, --port); the rest are on rootCommand.Flags. Their ordering
+	// here is independent of that partitioning.
+	order := []string{
+		"profile",
+		"verbose",
+		"version",
+		"help",
+		"print-env",
+		"otel",
+		"no-otel",
+		"no-otel-metrics",
+		"no-otel-logs",
+		"otel-metrics-table",
+		"otel-logs-table",
+		"model",
+		"upstream",
+		"log-file",
+		"proxy-api-key",
+		"tls-cert",
+		"tls-key",
+		"port",
+		"headless",
+		"idle-timeout",
+		"install-hooks",
+		"uninstall-hooks",
+		"headless-ensure",
+		"no-update-check",
+	}
+	byName := map[string]completion.FlagDef{}
+	for _, f := range rootCommand.AllFlags() {
+		byName[f.Name] = f.ToCompletion()
+	}
+	out := make([]completion.FlagDef, 0, len(order))
+	for _, name := range order {
+		f, ok := byName[name]
+		if !ok {
+			panic("completion_flags: order entry " + name + " not declared on rootCommand")
+		}
+		out = append(out, f)
+	}
+	return out
+}()
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-codex
-// owns. Anything not in this set is forwarded to the codex binary.
-// Derived from flagDefs so it can never drift from the completion script.
-var knownFlags = func() map[string]bool {
-	m := make(map[string]bool, len(flagDefs))
-	for _, f := range flagDefs {
-		m["--"+f.Name] = true
-	}
-	return m
-}()
+// owns. Anything not in this set is forwarded to the codex binary. Derived
+// directly from rootCommand so it can never drift from the tree — the tree
+// is the source of truth for which flags the binary recognises.
+var knownFlags = rootCommand.KnownFlags()

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -6,10 +6,13 @@ import "github.com/IceRhymers/databricks-claude/pkg/completion"
 // shell-script generation. Order is curated here (not implied by the tree)
 // because bash/zsh/fish completion output is order-sensitive — preserving
 // byte-equivalence with the pre-tree binary requires the original ordering
-// (--profile first, --port between --tls-key and --headless, etc.). Each
-// entry is derived from rootCommand so the tree remains the single source
-// of truth for which flags exist and what their descriptions / completers /
-// arg semantics are.
+// (--profile first, --port toward the end). Each entry is derived from
+// rootCommand so the tree remains the single source of truth for which
+// flags exist and what their descriptions / completers / arg semantics are.
+// #89 removed --headless and --idle-timeout from this slice (alongside the
+// rootCommand.Flags removal); they live on serveCommand now and are
+// reachable via the recursive subcommand-tree wiring in
+// rootCommand.CompletionSubcommands().
 //
 // Adding a new root flag requires:
 //  1. Append a FlagDef to rootCommand.Flags (or .Persistent) in commands.go.
@@ -34,8 +37,6 @@ var flagDefs = func() []completion.FlagDef {
 		"tls-cert",
 		"tls-key",
 		"port",
-		"headless",
-		"idle-timeout",
 		"no-update-check",
 	}
 	byName := map[string]completion.FlagDef{}
@@ -61,10 +62,12 @@ var knownFlags = rootCommand.KnownFlags()
 
 // knownSubcommands is the recursive shell-completion subcommand tree fed
 // to pkg/completion so `databricks-codex <TAB>` offers completion / update
-// / config / hooks, and `databricks-codex hooks <TAB>` offers install /
-// uninstall / session-start, `databricks-codex config <TAB>` offers otel
-// / show, etc. #87 introduced this wire-up alongside the dep bump to
-// databricks-claude v1.0.2 (which exports SubcommandDef); #88 adds the
-// hooks branch. See the doc-comment in internal/cmd/cmd.go for the prior
-// #86 omission.
+// / config / hooks / serve, and `databricks-codex hooks <TAB>` offers
+// install / uninstall / session-start, `databricks-codex config <TAB>`
+// offers otel / show, etc. #87 introduced this wire-up alongside the dep
+// bump to databricks-claude v1.0.2 (which exports SubcommandDef); #88
+// adds the hooks branch; #89 adds the serve leaf — picked up
+// automatically by the recursive walk now that serveCommand sits on
+// rootCommand.Subcommands. See the doc-comment in internal/cmd/cmd.go
+// for the prior #86 omission.
 var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/IceRhymers/databricks-codex
 
 go 1.22
 
-require github.com/IceRhymers/databricks-claude v0.17.0
+require github.com/IceRhymers/databricks-claude v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/IceRhymers/databricks-claude v0.17.0 h1:YPJgXMLBMmmr3uhgZWLTPbsikTnYOOpRdiDTWakzoQo=
-github.com/IceRhymers/databricks-claude v0.17.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v1.0.2 h1:kfmmOCDPGCbk8t5mDkLXqIQeLdyDEmW1NGKKW4Kw1cQ=
+github.com/IceRhymers/databricks-claude v1.0.2/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=

--- a/hooks.go
+++ b/hooks.go
@@ -20,7 +20,9 @@ var hooksKeyRegexp = regexp.MustCompile(`(?m)^\s*hooks\s*=`)
 
 // headlessEnsure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
-// Called by the SessionStart hook via: databricks-codex --headless-ensure
+// Called by the SessionStart hook via: databricks-codex hooks session-start
+// (#88 lifted this off the legacy --headless-ensure root flag; the entry
+// written by installHooks now invokes the subcommand spelling).
 //
 // The proxy shuts itself down via idle timeout — there is no corresponding
 // release hook because Codex CLI has no session-end event.
@@ -65,7 +67,7 @@ func installHooks(hooksPath string) error {
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
-				"command": "databricks-codex --headless-ensure",
+				"command": "databricks-codex hooks session-start",
 				"timeout": 15,
 			},
 		},
@@ -118,7 +120,7 @@ func uninstallHooks(hooksPath string) error {
 	return removeHooksFeatureFlag(configPath)
 }
 
-// removeDBXHooks removes any hook entries whose command contains "databricks-codex --headless".
+// removeDBXHooks removes any hook entries that databricks-codex installed.
 func removeDBXHooks(hooks map[string]interface{}) {
 	for event, val := range hooks {
 		arr, _ := val.([]interface{})
@@ -132,7 +134,13 @@ func removeDBXHooks(hooks map[string]interface{}) {
 	}
 }
 
-// isDBXHookEntry returns true if any nested hook command references databricks-codex --headless.
+// isDBXHookEntry returns true if any nested hook command was installed by
+// databricks-codex. Recognises both spellings so re-install / uninstall
+// stays idempotent across the #88 cutover:
+//   - "databricks-codex --headless..." — legacy entries written by the
+//     pre-#88 --install-hooks flag.
+//   - "databricks-codex hooks ..." — entries written by the new
+//     `hooks install` subcommand.
 func isDBXHookEntry(entry interface{}) bool {
 	m, ok := entry.(map[string]interface{})
 	if !ok {
@@ -141,11 +149,15 @@ func isDBXHookEntry(entry interface{}) bool {
 	inner, _ := m["hooks"].([]interface{})
 	for _, h := range inner {
 		hm, _ := h.(map[string]interface{})
-		if cmd, _ := hm["command"].(string); len(cmd) > 0 {
-			if len(cmd) >= len("databricks-codex --headless") &&
-				cmd[:len("databricks-codex --headless")] == "databricks-codex --headless" {
-				return true
-			}
+		cmd, _ := hm["command"].(string)
+		if cmd == "" {
+			continue
+		}
+		if strings.HasPrefix(cmd, "databricks-codex --headless") {
+			return true
+		}
+		if strings.HasPrefix(cmd, "databricks-codex hooks ") {
+			return true
 		}
 	}
 	return false

--- a/hooks.go
+++ b/hooks.go
@@ -26,13 +26,29 @@ var hooksKeyRegexp = regexp.MustCompile(`(?m)^\s*hooks\s*=`)
 //
 // The proxy shuts itself down via idle timeout — there is no corresponding
 // release hook because Codex CLI has no session-end event.
+//
+// #89: the spawned subprocess invokes the new `serve` subcommand instead of
+// the deleted `--headless` root flag. headless.Config.EnsureCommand replaces
+// the default `[]string{"--headless"}` prefix with `[]string{"serve"}`, so
+// pkg/headless.buildArgs now emits `databricks-codex serve --port=N
+// [--tls-cert=... --tls-key=...]`. Without this wiring, every SessionStart
+// hook firing would spawn a process that immediately fails arg parsing.
 func headlessEnsure(port int) error {
 	s := loadState()
+	return headless.Ensure(headlessEnsureConfig(port, s))
+}
+
+// headlessEnsureConfig assembles the headless.Config that headlessEnsure
+// passes to headless.Ensure. Extracted so a unit test can verify the
+// load-bearing fields (EnsureCommand routing through `serve`, the
+// $DATABRICKS_CODEX_MANAGED guard, the codex refcount path) without
+// spawning a real subprocess. Pure projection over (port, state).
+func headlessEnsureConfig(port int, s persistentState) headless.Config {
 	scheme := "http"
 	if s.TLSCert != "" {
 		scheme = "https"
 	}
-	return headless.Ensure(headless.Config{
+	return headless.Config{
 		Port:          port,
 		Scheme:        scheme,
 		TLSCert:       s.TLSCert,
@@ -40,7 +56,10 @@ func headlessEnsure(port int) error {
 		ManagedEnvVar: "DATABRICKS_CODEX_MANAGED",
 		LogPrefix:     "databricks-codex",
 		RefcountPath:  refcount.PathForPort(".databricks-codex-sessions", port),
-	})
+		// #89: spawn `databricks-codex serve --port=N` instead of the
+		// removed `databricks-codex --headless --port=N`.
+		EnsureCommand: []string{"serve"},
+	}
 }
 
 // installHooks merges the databricks-codex SessionStart and Stop hooks into

--- a/hooks_cmd.go
+++ b/hooks_cmd.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// runHooksCommand dispatches `databricks-codex hooks <subcommand> [flags]`.
+// args is everything after the literal "hooks" token (e.g. ["install"] or
+// ["session-start", "--port", "49154"]).
+//
+// Each subcommand is a thin wrapper around the existing hooks.go logic:
+//   - install       → installHooks(~/.codex/hooks.json)
+//   - uninstall     → uninstallHooks(~/.codex/hooks.json)
+//   - session-start → headlessEnsure(resolved port)
+//
+// The dispatcher uses cmd.Command.Parse on the matching subcommand node so
+// flag parsing stays consistent with the tree's declared semantics
+// (TakesArg, Short aliases, --flag=value forms). The parity test in
+// main_test.go walks rootCommand.Subcommand("hooks").Subcommands and
+// confirms every child name has a case here — drift fails loudly.
+func runHooksCommand(args []string) error {
+	if len(args) == 0 {
+		printHooksHelp()
+		return fmt.Errorf("hooks: missing subcommand (expected: install, uninstall, session-start)")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+
+	node := hooksCommand.Subcommand(sub)
+	if node == nil {
+		printHooksHelp()
+		return fmt.Errorf("hooks: unknown subcommand %q (expected: install, uninstall, session-start)", sub)
+	}
+
+	parsed, err := node.Parse(rest)
+	if err != nil {
+		return fmt.Errorf("hooks %s: %w", sub, err)
+	}
+	if parsed.Bools["help"] {
+		printSubHelp(*node)
+		return nil
+	}
+
+	switch sub {
+	case "install":
+		return runHooksInstall()
+	case "uninstall":
+		return runHooksUninstall()
+	case "session-start":
+		return runHooksSessionStart(parsed.Strings["port"], parsed.Set["port"])
+	default:
+		// Unreachable — Subcommand() lookup above already guards this, but
+		// the parity test still walks here so a forgotten case fails the
+		// build rather than silently no-opping.
+		return fmt.Errorf("hooks: unknown subcommand %q", sub)
+	}
+}
+
+// runHooksInstall is a thin wrapper around installHooks that resolves
+// ~/.codex/hooks.json from $HOME and prints the success message
+// previously emitted by main.go's --install-hooks branch.
+func runHooksInstall() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	hp := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := installHooks(hp); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-codex: hooks installed — SessionStart hook added to ~/.codex/hooks.json")
+	return nil
+}
+
+// runHooksUninstall is a thin wrapper around uninstallHooks.
+func runHooksUninstall() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	hp := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := uninstallHooks(hp); err != nil {
+		return fmt.Errorf("uninstall: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-codex: hooks removed from ~/.codex/hooks.json")
+	return nil
+}
+
+// runHooksSessionStart resolves the port and calls headlessEnsure.
+// MUST remain fast/fail-fast — no interactive auth flow.
+func runHooksSessionStart(portValue string, portSet bool) error {
+	state := loadState()
+	portFlag := 0
+	if portSet && portValue != "" {
+		n, err := strconv.Atoi(portValue)
+		if err != nil {
+			return fmt.Errorf("session-start: --port: %q is not an integer", portValue)
+		}
+		portFlag = n
+	}
+	port := resolvePort(portFlag, state)
+	return headlessEnsure(port)
+}
+
+// printHooksHelp prints the top-level `hooks` help body.
+func printHooksHelp() {
+	fmt.Fprint(os.Stderr, hooksHelpTemplate)
+}
+
+// printSubHelp prints a subcommand's Long body when --help is passed.
+// Falls back to programmatic rendering when Long is empty.
+func printSubHelp(c cmd.Command) {
+	if c.Long != "" {
+		fmt.Fprint(os.Stderr, c.Long)
+		return
+	}
+	_ = cmd.Render(os.Stderr, c, nil)
+}

--- a/hooks_cmd_test.go
+++ b/hooks_cmd_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHooksCommandTreeParity verifies bidirectional parity between the
+// hooksCommand subcommand declaration and runHooksCommand's dispatch
+// switch:
+//
+//   - tree → runner: every child name declared on hooksCommand must be
+//     accepted by runHooksCommand. We probe each with --help so the
+//     handler short-circuits before doing real work (no filesystem
+//     mutation, no proxy probe).
+//   - runner → tree: every dispatch keyword recognised by runHooksCommand
+//     must appear on the tree. The set is hard-coded here so a future
+//     dispatch addition without a tree entry trips the check.
+//
+// Bidirectional verification documented in #88 commit body: the test was
+// confirmed to fail when hooksCommand was temporarily removed from
+// rootCommand.Subcommands (parity flip) and again when a child was
+// removed from hooksCommand (tree shrink) — i.e. drift in either
+// direction trips this test.
+func TestHooksCommandTreeParity(t *testing.T) {
+	expected := map[string]bool{
+		"install":       true,
+		"uninstall":     true,
+		"session-start": true,
+	}
+
+	if len(hooksCommand.Subcommands) != len(expected) {
+		t.Errorf("hooksCommand has %d subcommands; expected %d (drift between tree and runHooksCommand)",
+			len(hooksCommand.Subcommands), len(expected))
+	}
+
+	for _, sub := range hooksCommand.Subcommands {
+		if !expected[sub.Name] {
+			t.Errorf("hooksCommand declares %q but runHooksCommand has no case for it", sub.Name)
+			continue
+		}
+		// --help short-circuits before doing real work.
+		err := runHooksCommand([]string{sub.Name, "--help"})
+		if err != nil {
+			t.Errorf("runHooksCommand([%q --help]) returned %v; the dispatcher should accept this name", sub.Name, err)
+		}
+	}
+
+	// Inverse: every dispatch keyword must appear on the tree.
+	for name := range expected {
+		if hooksCommand.Subcommand(name) == nil {
+			t.Errorf("runHooksCommand recognises %q but hooksCommand has no child for it", name)
+		}
+	}
+}
+
+// TestRunHooksCommand_UnknownSubcommand verifies the dispatcher rejects
+// unknown subcommands with a non-nil error and prints help to stderr.
+func TestRunHooksCommand_UnknownSubcommand(t *testing.T) {
+	err := runHooksCommand([]string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error %q should mention the unknown subcommand", err)
+	}
+}
+
+// TestRunHooksCommand_MissingSubcommand verifies the dispatcher rejects
+// bare `hooks` with no subcommand.
+func TestRunHooksCommand_MissingSubcommand(t *testing.T) {
+	err := runHooksCommand(nil)
+	if err == nil {
+		t.Fatal("expected error for missing subcommand, got nil")
+	}
+}
+
+// TestHooksInstallUninstall_Idempotency verifies that
+// install → install → uninstall → uninstall produces a clean state with
+// no extraneous diff in ~/.codex/hooks.json. Drives the round-trip
+// through the dispatcher (runHooksCommand) rather than the lower-level
+// installHooks/uninstallHooks helpers so the wiring between subcommand
+// dispatch and the existing hooks.go logic is exercised.
+func TestHooksInstallUninstall_Idempotency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	// install x2 — second call must be idempotent.
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	first, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after first install: %v", err)
+	}
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	second, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after second install: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("install is not idempotent — second install diffed:\nfirst:\n%s\nsecond:\n%s",
+			first, second)
+	}
+
+	// SessionStart count must be 1 (not 2) after double install.
+	var doc map[string]interface{}
+	if err := json.Unmarshal(second, &doc); err != nil {
+		t.Fatalf("parse hooks.json after double install: %v", err)
+	}
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 SessionStart entry after install x2, got %d", len(ss))
+	}
+
+	// uninstall x2 — second call must be a no-op (no error, no panic).
+	if err := runHooksCommand([]string{"uninstall"}); err != nil {
+		t.Fatalf("first uninstall: %v", err)
+	}
+	if err := runHooksCommand([]string{"uninstall"}); err != nil {
+		t.Fatalf("second uninstall: %v", err)
+	}
+
+	// hooks.json should still parse and have no databricks-codex entries.
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after double uninstall: %v", err)
+	}
+	var clean map[string]interface{}
+	if err := json.Unmarshal(raw, &clean); err != nil {
+		t.Fatalf("parse hooks.json after double uninstall: %v", err)
+	}
+	if _, ok := clean["hooks"]; ok {
+		t.Errorf("expected no hooks key after uninstall, got: %s", raw)
+	}
+}
+
+// TestHooksInstall_WritesNewSubcommandSpelling verifies that the entry
+// written by `hooks install` invokes the new subcommand spelling
+// (`databricks-codex hooks session-start`), not the legacy
+// `--headless-ensure` flag. Locks the hook JSON contract for #88.
+func TestHooksInstall_WritesNewSubcommandSpelling(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+	if !strings.Contains(string(raw), "databricks-codex hooks session-start") {
+		t.Errorf("expected hooks.json to invoke the new subcommand spelling, got:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "--headless-ensure") {
+		t.Errorf("hooks.json still invokes the removed --headless-ensure flag:\n%s", raw)
+	}
+}
+
+// TestHooksRunCommand_LegacyDetectorReplacement verifies that an existing
+// hooks.json containing a legacy `--headless-ensure` entry is cleanly
+// replaced (not duplicated) by `hooks install`. Backstops the cutover —
+// users who installed via the pre-#88 binary get a clean re-install.
+func TestHooksRunCommand_LegacyDetectorReplacement(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	// Seed hooks.json with the legacy entry.
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "startup",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "databricks-codex --headless-ensure",
+							"timeout": float64(15),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("install over legacy: %v", err)
+	}
+
+	raw, _ := os.ReadFile(hooksPath)
+	if strings.Contains(string(raw), "--headless-ensure") {
+		t.Errorf("legacy --headless-ensure entry survived re-install:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "databricks-codex hooks session-start") {
+		t.Errorf("expected new subcommand spelling after re-install, got:\n%s", raw)
+	}
+	// Exactly one SessionStart entry — no duplicates.
+	var doc map[string]interface{}
+	json.Unmarshal(raw, &doc)
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 SessionStart entry after legacy replacement, got %d", len(ss))
+	}
+}
+
+// TestRootSubcommandsIncludeHooks verifies hooksCommand is registered on
+// the root tree. This is the parity hook for the bidirectional check
+// described in the issue: temporarily removing hooksCommand from
+// rootCommand.Subcommands flips this assertion to fail, confirming the
+// tree wiring is load-bearing.
+func TestRootSubcommandsIncludeHooks(t *testing.T) {
+	if rootCommand.Subcommand("hooks") == nil {
+		t.Fatal("rootCommand has no `hooks` subcommand — tree wiring lost")
+	}
+}

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -441,17 +441,23 @@ func splitLines(s string) []string {
 }
 
 // TestIsDBXHookEntry verifies detection of databricks-codex hook entries.
+// Covers both the legacy --headless-* spellings (entries left over from
+// pre-#88 installs) and the new `hooks` subcommand spellings, so a
+// re-install or uninstall replaces both cleanly.
 func TestIsDBXHookEntry(t *testing.T) {
 	tests := []struct {
 		name string
 		cmd  string
 		want bool
 	}{
-		{"ensure command", "databricks-codex --headless-ensure", true},
-		{"release command", "databricks-codex --headless-release", true},
-		{"headless base", "databricks-codex --headless", true},
+		{"legacy ensure command", "databricks-codex --headless-ensure", true},
+		{"legacy release command", "databricks-codex --headless-release", true},
+		{"legacy headless base", "databricks-codex --headless", true},
+		{"new session-start command", "databricks-codex hooks session-start", true},
+		{"new install command", "databricks-codex hooks install", true},
 		{"unrelated command", "my-custom-hook", false},
 		{"partial match", "databricks-codex --help", false},
+		{"hooks-prefixed unrelated", "databricks-codex hooksy-thing", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,385 @@
+// Package cmd is the in-repo command-tree registry: a single source of truth
+// for the databricks-codex CLI surface (flag set, help text, shell
+// completion). The tree is consumed by:
+//
+//   - parseArgs (main package) — derives the set of "--flag" names the
+//     binary recognises; anything not in the tree is forwarded transparently
+//     to the wrapped codex binary.
+//   - handleHelp (main package) — renders help text from the tree, replacing
+//     the giant hand-maintained printf that previously lived in main.go.
+//   - pkg/completion — receives the tree's CompletionFlags to emit
+//     bash/zsh/fish completion scripts.
+//
+// Boundary: this package MUST NOT import the root main package; the
+// dependency arrow points one way (main → internal/cmd), so the tree can
+// later be lifted to pkg/ without disentangling cycles.
+//
+// Status: #86 migrates the *root* command onto the tree. config / hooks /
+// serve continue to live as root flags + their own dispatch in main.go;
+// their migration onto Subcommands is tracked in #87/#88/#89. The Persistent
+// slice already holds --profile / --port so subcommand inheritance can be
+// wired up when those migrations land.
+//
+// Note vs. the sister databricks-claude implementation: this port omits the
+// CompletionSubcommands() method because the pinned databricks-claude
+// pkg/completion (v0.17.0) does not yet expose SubcommandDef. The cross-repo
+// dependency bump is deliberately out of scope for #86; the method will be
+// added back when the codex repo adopts a databricks-claude release that
+// carries SubcommandDef.
+package cmd
+
+import (
+	"io"
+	"strings"
+
+	"github.com/IceRhymers/databricks-claude/pkg/completion"
+)
+
+// FlagDef describes one CLI flag. Superset of pkg/completion.FlagDef:
+// carries everything the shell-completion generator needs (Name, Short,
+// Description, TakesArg, Completer) plus resolution-chain metadata
+// (StateKey, EnvVar, MDMKey, Default) so a future tree-driven resolver
+// can derive the flag → env → state → MDM → default lookup order from the
+// same declaration. The resolution-chain fields are CARRIED in #86 but
+// not yet consumed; #87/#88/#89 wire them into the actual lookup code.
+type FlagDef struct {
+	// Name is the flag spelled without the "--" prefix, e.g. "profile".
+	Name string
+	// Short is the optional single-character alias spelled without the "-"
+	// prefix, e.g. "v" for --verbose. Empty means no short alias.
+	Short string
+	// Description is the one-line description shown in help text and
+	// completion scripts. Keep it tight — the help renderer wraps long
+	// descriptions but the completion emitters do not.
+	Description string
+	// TakesArg is true if the flag consumes the next token as its value.
+	TakesArg bool
+	// Completer is the named completer function fed to pkg/completion.
+	// Reserved values: "__databricks_profiles", "__files". Empty means no
+	// value completion (the flag's value is opaque to the shell).
+	Completer string
+
+	// --- Resolution-chain metadata (carried; not yet consumed) ---
+
+	// StateKey is the JSON key under ~/.codex/.databricks-codex.json that
+	// persists this flag's value across sessions. Empty if the flag is
+	// not persistable.
+	StateKey string
+	// EnvVar is the environment variable that may seed this flag's value
+	// when the flag itself is absent. Empty if the flag has no env tier.
+	EnvVar string
+	// MDMKey is the key under the com.icerhymers.databricks-codex MDM
+	// domain that admins can pin. Empty if the flag has no MDM tier.
+	MDMKey string
+	// Default is the literal default string when no other tier supplies a
+	// value. Stored as string so the tree stays uniform across types;
+	// callers parse it with strconv when needed.
+	Default string
+}
+
+// ToCompletion narrows a FlagDef to the pkg/completion.FlagDef the shell
+// emitters consume. The resolution-chain metadata is dropped here — it has
+// no completion-script meaning.
+func (f FlagDef) ToCompletion() completion.FlagDef {
+	return completion.FlagDef{
+		Name:        f.Name,
+		Short:       f.Short,
+		Description: f.Description,
+		TakesArg:    f.TakesArg,
+		Completer:   f.Completer,
+	}
+}
+
+// Command is one node in the CLI tree.
+//
+// A Command can be:
+//   - A leaf with Run set (e.g. "completion", "update").
+//   - A branch with Subcommands (e.g. the root, or a future "serve" with
+//     install/uninstall/status children).
+//   - A main-driven node with Run nil (the root, today): main() walks the
+//     tree to derive parsable flags + help text but keeps its own dispatch
+//     loop. Run will be populated when subcommands migrate onto the tree.
+//
+// Persistent flags are conceptually inherited by every subcommand (a child
+// command sees its own Flags ++ every ancestor's Persistent). Inheritance
+// is declared here but not yet enforced at parse time; subcommand parsing
+// still lives in hand-rolled FlagSets pending #87/#88/#89.
+type Command struct {
+	// Name is the command's word as typed on the CLI (e.g. "serve").
+	// For the root command, Name is the binary name ("databricks-codex").
+	Name string
+	// Short is the one-line description shown when this command appears
+	// as a child in a parent's "Subcommands:" listing.
+	Short string
+	// Long is the full help body. When non-empty, Render writes it
+	// verbatim (after substituting registered template variables — see
+	// Render). When empty, Render falls back to a programmatic table
+	// derived from Flags / Persistent / Subcommands. Today the root
+	// carries a hand-formatted Long for byte-for-byte help equivalence
+	// with the legacy printf; future subcommands can opt into the
+	// programmatic renderer by leaving Long empty.
+	Long string
+	// Flags are the flags local to this command.
+	Flags []FlagDef
+	// Persistent flags are inherited by every descendant subcommand.
+	// On the root: --profile and --port live here so they remain
+	// available everywhere once child commands migrate onto the tree.
+	Persistent []FlagDef
+	// Subcommands are the immediate children.
+	Subcommands []Command
+	// Run is the leaf executor. Nil for nodes whose dispatch lives in
+	// main() (the root in #86) or for non-leaf branches whose children
+	// own execution.
+	Run func(args []string) error
+}
+
+// Subcommand returns a pointer to the immediate child Command with the given
+// name, or nil when no such child exists. Helper for runners that dispatch
+// nested subcommands (e.g. `serve install` finding the install node under
+// the serve node) without re-walking the slice each time.
+func (c Command) Subcommand(name string) *Command {
+	for i := range c.Subcommands {
+		if c.Subcommands[i].Name == name {
+			return &c.Subcommands[i]
+		}
+	}
+	return nil
+}
+
+// AllFlags returns Persistent followed by Flags as a single ordered slice.
+// Persistent comes first so subcommand parsing (when it migrates) sees
+// inherited flags before its own; the help renderer follows the same
+// order so persistent flags surface near the top of the flag table.
+func (c Command) AllFlags() []FlagDef {
+	out := make([]FlagDef, 0, len(c.Persistent)+len(c.Flags))
+	out = append(out, c.Persistent...)
+	out = append(out, c.Flags...)
+	return out
+}
+
+// CompletionFlags returns AllFlags converted to pkg/completion.FlagDef so
+// it can be passed straight into completion.Run / GenerateBash / etc.
+func (c Command) CompletionFlags() []completion.FlagDef {
+	flags := c.AllFlags()
+	out := make([]completion.FlagDef, len(flags))
+	for i, f := range flags {
+		out[i] = f.ToCompletion()
+	}
+	return out
+}
+
+// KnownFlags returns the set of "--flag" names this command's parser
+// recognises. Includes Persistent ++ Flags. Does NOT walk into
+// Subcommands — each child command is parsed by its own dispatcher and
+// owns its own KnownFlags.
+func (c Command) KnownFlags() map[string]bool {
+	flags := c.AllFlags()
+	m := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		m["--"+f.Name] = true
+	}
+	return m
+}
+
+// Render writes the command's help body to w. If c.Long is non-empty it
+// is used verbatim, with each "{{key}}" placeholder replaced by vars[key].
+// If c.Long is empty, Render falls back to a programmatic table built
+// from c.Flags / c.Persistent / c.Subcommands (suitable for child
+// commands that migrate onto the tree without curating a Long blob).
+//
+// Today only the root supplies a Long; the programmatic fallback exists
+// so #87/#88/#89 migrations can drop Long with minimal diff.
+func Render(w io.Writer, c Command, vars map[string]string) error {
+	if c.Long != "" {
+		body := c.Long
+		for k, v := range vars {
+			body = strings.ReplaceAll(body, "{{"+k+"}}", v)
+		}
+		_, err := io.WriteString(w, body)
+		return err
+	}
+	return renderProgrammatic(w, c)
+}
+
+// ParseResult is the generic output of Command.Parse. Runners map this into
+// their own typed flag struct (e.g. configFlags, hooksFlags) so downstream
+// resolution code is untouched. Three maps so callers can answer the three
+// questions runners actually ask:
+//
+//   - "what string did the user provide for --flag?"     → Strings
+//   - "did the user pass --flag (boolean toggle)?"        → Bools
+//   - "did the user provide --flag at all (used to gate
+//     state-persistence writes via the sentinel guard)?"  → Set
+//
+// Strings and Bools are populated only for known flags (declared on the
+// Command's Persistent + Flags). Unknown flags AND any leftover positional
+// tokens are appended to Positional in input order so runners can still
+// detect e.g. an action keyword like `config otel enable` or, for the
+// root, forward unknowns to the wrapped codex binary.
+type ParseResult struct {
+	Strings    map[string]string
+	Bools      map[string]bool
+	Set        map[string]bool
+	Positional []string
+}
+
+// Parse evaluates args against c's known flags (Persistent ++ Flags) and
+// returns a ParseResult. Behavior mirrors the hand-rolled scanners that
+// previously lived in the various subcommand files:
+//
+//   - Supports --flag value AND --flag=value forms.
+//   - Boolean flags (TakesArg=false) consume no value. An explicit
+//     --flag=false / --flag=0 / --flag=no sets the bool to false; anything
+//     else (including bare --flag) sets it to true.
+//   - Bare "--" terminates flag parsing; everything after is appended to
+//     Positional verbatim.
+//   - Short aliases declared via FlagDef.Short are honoured (-v → --verbose,
+//     -h → --help when those flags are declared on c).
+//   - Unknown long flags and unknown short flags are appended to Positional
+//     unchanged. This preserves the historical tolerance of the hand-rolled
+//     scanners (which silently ignored unknown flags) and lets root callers
+//     forward unknowns to codex.
+//   - A TakesArg flag that appears without a value (last token, no "=") gets
+//     an empty string in Strings — matches the hand-rolled scanner behaviour
+//     where bare `--port` left port=0 rather than erroring.
+func (c Command) Parse(args []string) (*ParseResult, error) {
+	flagsByName := make(map[string]FlagDef)
+	flagsByShort := make(map[string]FlagDef)
+	for _, f := range c.AllFlags() {
+		flagsByName[f.Name] = f
+		if f.Short != "" {
+			flagsByShort[f.Short] = f
+		}
+	}
+
+	res := &ParseResult{
+		Strings: map[string]string{},
+		Bools:   map[string]bool{},
+		Set:     map[string]bool{},
+	}
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+
+		if a == "--" {
+			res.Positional = append(res.Positional, args[i+1:]...)
+			break
+		}
+
+		if strings.HasPrefix(a, "--") {
+			name := a[2:]
+			value := ""
+			hasValue := false
+			if eq := strings.Index(name, "="); eq >= 0 {
+				value = name[eq+1:]
+				name = name[:eq]
+				hasValue = true
+			}
+			f, known := flagsByName[name]
+			if !known {
+				res.Positional = append(res.Positional, a)
+				continue
+			}
+			if f.TakesArg {
+				if !hasValue && i+1 < len(args) {
+					i++
+					value = args[i]
+				}
+				res.Strings[name] = value
+				res.Set[name] = true
+			} else {
+				res.Bools[name] = !isFalsy(hasValue, value)
+				res.Set[name] = true
+			}
+			continue
+		}
+
+		if len(a) > 1 && a[0] == '-' {
+			short := a[1:]
+			value := ""
+			hasValue := false
+			if eq := strings.Index(short, "="); eq >= 0 {
+				value = short[eq+1:]
+				short = short[:eq]
+				hasValue = true
+			}
+			f, known := flagsByShort[short]
+			if !known {
+				res.Positional = append(res.Positional, a)
+				continue
+			}
+			if f.TakesArg {
+				if !hasValue && i+1 < len(args) {
+					i++
+					value = args[i]
+				}
+				res.Strings[f.Name] = value
+				res.Set[f.Name] = true
+			} else {
+				res.Bools[f.Name] = !isFalsy(hasValue, value)
+				res.Set[f.Name] = true
+			}
+			continue
+		}
+
+		res.Positional = append(res.Positional, a)
+	}
+
+	return res, nil
+}
+
+// isFalsy reports whether an explicit boolean-flag value should set the bool
+// to false. Bare flag (hasValue=false) is always truthy. Explicit values
+// "0", "false", "no" (case-insensitive) are falsy; everything else is truthy.
+func isFalsy(hasValue bool, value string) bool {
+	if !hasValue {
+		return false
+	}
+	return value == "0" || strings.EqualFold(value, "false") || strings.EqualFold(value, "no")
+}
+
+// renderProgrammatic emits a default help layout for commands that don't
+// curate a Long blob. Used by the programmatic fallback in Render.
+func renderProgrammatic(w io.Writer, c Command) error {
+	var b strings.Builder
+	if c.Short != "" {
+		b.WriteString(c.Name)
+		b.WriteString(" — ")
+		b.WriteString(c.Short)
+		b.WriteString("\n\n")
+	}
+	if flags := c.AllFlags(); len(flags) > 0 {
+		b.WriteString("Flags:\n")
+		for _, f := range flags {
+			b.WriteString("  --")
+			b.WriteString(f.Name)
+			if f.Short != "" {
+				b.WriteString(", -")
+				b.WriteString(f.Short)
+			}
+			if f.TakesArg {
+				b.WriteString(" <value>")
+			}
+			if f.Description != "" {
+				b.WriteString("    ")
+				b.WriteString(f.Description)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(c.Subcommands) > 0 {
+		b.WriteString("Subcommands:\n")
+		for _, s := range c.Subcommands {
+			b.WriteString("  ")
+			b.WriteString(s.Name)
+			if s.Short != "" {
+				b.WriteString("    ")
+				b.WriteString(s.Short)
+			}
+			b.WriteString("\n")
+		}
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -20,12 +20,13 @@
 // slice already holds --profile / --port so subcommand inheritance can be
 // wired up when those migrations land.
 //
-// Note vs. the sister databricks-claude implementation: this port omits the
-// CompletionSubcommands() method because the pinned databricks-claude
-// pkg/completion (v0.17.0) does not yet expose SubcommandDef. The cross-repo
-// dependency bump is deliberately out of scope for #86; the method will be
-// added back when the codex repo adopts a databricks-claude release that
-// carries SubcommandDef.
+// Note vs. the sister databricks-claude implementation: #86 deliberately
+// omitted CompletionSubcommands() because the pinned databricks-claude
+// pkg/completion (v0.17.0) did not yet expose SubcommandDef. #88 adopts
+// databricks-claude v1.0.2 (which exports SubcommandDef) alongside the
+// hooks subcommand migration, and re-introduces the method here so nested
+// shell completion can offer e.g. `hooks <TAB>` → install/uninstall/
+// session-start.
 package cmd
 
 import (
@@ -164,6 +165,25 @@ func (c Command) CompletionFlags() []completion.FlagDef {
 	out := make([]completion.FlagDef, len(flags))
 	for i, f := range flags {
 		out[i] = f.ToCompletion()
+	}
+	return out
+}
+
+// CompletionSubcommands returns the immediate children as
+// pkg/completion.SubcommandDef. The conversion is RECURSIVE: each child
+// carries its own Flags and Subcommands so the shell-completion generator
+// can offer nested completion (e.g. `hooks install --<TAB>` →
+// install-scoped flags). Flags include each child's Persistent ++ Flags so
+// inherited flags surface alongside the child's own.
+func (c Command) CompletionSubcommands() []completion.SubcommandDef {
+	out := make([]completion.SubcommandDef, len(c.Subcommands))
+	for i, s := range c.Subcommands {
+		out[i] = completion.SubcommandDef{
+			Name:        s.Name,
+			Description: s.Short,
+			Flags:       s.CompletionFlags(),
+			Subcommands: s.CompletionSubcommands(),
+		}
 	}
 	return out
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -172,9 +172,14 @@ func (c Command) CompletionFlags() []completion.FlagDef {
 // CompletionSubcommands returns the immediate children as
 // pkg/completion.SubcommandDef. The conversion is RECURSIVE: each child
 // carries its own Flags and Subcommands so the shell-completion generator
-// can offer nested completion (e.g. `hooks install --<TAB>` →
-// install-scoped flags). Flags include each child's Persistent ++ Flags so
-// inherited flags surface alongside the child's own.
+// can offer nested completion (e.g. `config <TAB>` → otel/show, then
+// `config otel <TAB>` → enable/disable; `hooks install --<TAB>` →
+// install-scoped flags). Flags include each child's Persistent ++ Flags
+// so inherited flags surface alongside the child's own.
+//
+// Added in #87 alongside the databricks-claude v0.17.0 → v1.0.2 bump that
+// exposes pkg/completion.SubcommandDef — the foundation in #86 deliberately
+// omitted this method because the pinned dep didn't carry the type yet.
 func (c Command) CompletionSubcommands() []completion.SubcommandDef {
 	out := make([]completion.SubcommandDef, len(c.Subcommands))
 	for i, s := range c.Subcommands {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAllFlagsOrdersPersistentBeforeFlags(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile"}, {Name: "port"}},
+		Flags:      []FlagDef{{Name: "verbose"}},
+	}
+	got := c.AllFlags()
+	want := []string{"profile", "port", "verbose"}
+	if len(got) != len(want) {
+		t.Fatalf("AllFlags len=%d, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("AllFlags[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+	}
+}
+
+func TestKnownFlagsCoversPersistentAndLocal(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile"}},
+		Flags:      []FlagDef{{Name: "verbose"}, {Name: "port", TakesArg: true}},
+	}
+	known := c.KnownFlags()
+	for _, want := range []string{"--profile", "--verbose", "--port"} {
+		if !known[want] {
+			t.Errorf("KnownFlags missing %q", want)
+		}
+	}
+	if known["--unknown"] {
+		t.Errorf("KnownFlags should not contain --unknown")
+	}
+}
+
+func TestToCompletionDropsResolutionMetadata(t *testing.T) {
+	f := FlagDef{
+		Name:        "profile",
+		Short:       "p",
+		Description: "Databricks profile",
+		TakesArg:    true,
+		Completer:   "__databricks_profiles",
+		StateKey:    "profile",
+		EnvVar:      "DATABRICKS_CONFIG_PROFILE",
+		MDMKey:      "databricksProfile",
+		Default:     "DEFAULT",
+	}
+	got := f.ToCompletion()
+	if got.Name != "profile" || got.Short != "p" || got.Description != "Databricks profile" ||
+		!got.TakesArg || got.Completer != "__databricks_profiles" {
+		t.Errorf("ToCompletion lost completion-relevant fields: %+v", got)
+	}
+}
+
+func TestRenderUsesLongVerbatimWithVarSubstitution(t *testing.T) {
+	c := Command{Long: "version={{Version}}\n"}
+	var buf bytes.Buffer
+	if err := Render(&buf, c, map[string]string{"Version": "1.2.3"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if buf.String() != "version=1.2.3\n" {
+		t.Errorf("Render output = %q, want %q", buf.String(), "version=1.2.3\n")
+	}
+}
+
+// --- Parse tests ---
+
+func TestParse_LongFlagSpaceForm(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, err := c.Parse([]string{"--profile", "prod"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if r.Strings["profile"] != "prod" || !r.Set["profile"] {
+		t.Errorf("expected profile=prod set=true, got %+v", r)
+	}
+}
+
+func TestParse_LongFlagEqualForm(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile=prod"})
+	if r.Strings["profile"] != "prod" || !r.Set["profile"] {
+		t.Errorf("expected profile=prod set=true, got %+v", r)
+	}
+}
+
+func TestParse_BoolFlag(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "verbose"}}}
+	r, _ := c.Parse([]string{"--verbose"})
+	if !r.Bools["verbose"] || !r.Set["verbose"] {
+		t.Errorf("expected verbose=true set=true, got %+v", r)
+	}
+}
+
+func TestParse_BoolFlagExplicitFalse(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "daemon"}}}
+	for _, v := range []string{"--daemon=false", "--daemon=0", "--daemon=no", "--daemon=NO"} {
+		r, _ := c.Parse([]string{v})
+		if r.Bools["daemon"] {
+			t.Errorf("%q: expected daemon=false, got true", v)
+		}
+		if !r.Set["daemon"] {
+			t.Errorf("%q: expected set=true even on falsy explicit", v)
+		}
+	}
+}
+
+func TestParse_ShortAlias(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "verbose", Short: "v"}, {Name: "help", Short: "h"}}}
+	r, _ := c.Parse([]string{"-v", "-h"})
+	if !r.Bools["verbose"] || !r.Bools["help"] {
+		t.Errorf("expected -v→verbose, -h→help, got %+v", r)
+	}
+}
+
+func TestParse_PersistentInherited(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile", TakesArg: true}},
+		Flags:      []FlagDef{{Name: "log-file", TakesArg: true}},
+	}
+	r, _ := c.Parse([]string{"--profile", "p", "--log-file", "/tmp/x"})
+	if r.Strings["profile"] != "p" || r.Strings["log-file"] != "/tmp/x" {
+		t.Errorf("persistent + local flag: got %+v", r)
+	}
+}
+
+func TestParse_UnknownLongFlagToPositional(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--unknown", "--profile", "x", "--also-unknown=val"})
+	if r.Strings["profile"] != "x" {
+		t.Errorf("known flag still consumed: got %+v", r)
+	}
+	want := []string{"--unknown", "--also-unknown=val"}
+	if len(r.Positional) != len(want) || r.Positional[0] != want[0] || r.Positional[1] != want[1] {
+		t.Errorf("Positional = %v, want %v", r.Positional, want)
+	}
+}
+
+func TestParse_DoubleDashTerminator(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile", "p", "--", "--help", "rest"})
+	if r.Strings["profile"] != "p" {
+		t.Errorf("--profile should be consumed before --, got %+v", r)
+	}
+	want := []string{"--help", "rest"}
+	if len(r.Positional) != len(want) || r.Positional[0] != want[0] || r.Positional[1] != want[1] {
+		t.Errorf("Positional after --: %v, want %v", r.Positional, want)
+	}
+}
+
+func TestParse_PositionalAction(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"generate-config", "--profile", "p"})
+	if len(r.Positional) != 1 || r.Positional[0] != "generate-config" {
+		t.Errorf("Positional: got %v, want [generate-config]", r.Positional)
+	}
+	if r.Strings["profile"] != "p" {
+		t.Errorf("flag after positional should still parse, got %+v", r)
+	}
+}
+
+func TestParse_BareTakesArgAtEnd(t *testing.T) {
+	// Mirrors the hand-rolled scanner tolerance: bare `--profile` with no
+	// following token leaves the value empty rather than erroring.
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile"})
+	if r.Strings["profile"] != "" || !r.Set["profile"] {
+		t.Errorf("bare --profile at end: got %+v, want empty string + Set=true", r)
+	}
+}
+
+func TestParse_SetTrueGuardsStatePersistence(t *testing.T) {
+	// The sentinel-guard contract from shouldPersistOTELTable: Set must be
+	// true ONLY when the user explicitly provided the flag, never when the
+	// flag was absent. Drives the parity between the historical *Set bools
+	// and the new ParseResult.Set map.
+	c := Command{Flags: []FlagDef{{Name: "otel-metrics-table", TakesArg: true}}}
+	r, _ := c.Parse([]string{})
+	if r.Set["otel-metrics-table"] {
+		t.Errorf("Set should be false when flag absent, got %+v", r)
+	}
+	r2, _ := c.Parse([]string{"--otel-metrics-table=cat.s.t"})
+	if !r2.Set["otel-metrics-table"] || r2.Strings["otel-metrics-table"] != "cat.s.t" {
+		t.Errorf("Set should be true with value, got %+v", r2)
+	}
+}
+
+func TestParse_NestedSubcommandFlagsOnDeepest(t *testing.T) {
+	// install command inherits --profile from parent serve via Persistent.
+	// (The runner is responsible for walking the chain; Parse itself sees a
+	// flat AllFlags.) This test pins that AllFlags on a child with declared
+	// Persistent ++ Flags accepts both.
+	install := Command{
+		Persistent: []FlagDef{{Name: "profile", TakesArg: true}},
+		Flags:      []FlagDef{{Name: "skip-auth-check"}},
+	}
+	r, _ := install.Parse([]string{"--profile", "prod", "--skip-auth-check"})
+	if r.Strings["profile"] != "prod" || !r.Bools["skip-auth-check"] {
+		t.Errorf("nested-flag parse: got %+v", r)
+	}
+}
+
+func TestRenderFallsBackToProgrammaticWhenLongIsEmpty(t *testing.T) {
+	c := Command{
+		Name:  "demo",
+		Short: "Example",
+		Flags: []FlagDef{{Name: "verbose", Description: "Enable debug"}},
+		Subcommands: []Command{
+			{Name: "child", Short: "A child"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, c, nil); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"demo — Example", "--verbose", "Enable debug", "child", "A child"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Render fallback missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestSubcommandReturnsPointerOrNil verifies the helper used by future
+// subcommand-dispatching runners (#87/#88/#89).
+func TestSubcommandReturnsPointerOrNil(t *testing.T) {
+	c := Command{Subcommands: []Command{
+		{Name: "completion"},
+		{Name: "update"},
+	}}
+	if got := c.Subcommand("completion"); got == nil || got.Name != "completion" {
+		t.Errorf("Subcommand(\"completion\") = %v", got)
+	}
+	if got := c.Subcommand("missing"); got != nil {
+		t.Errorf("Subcommand(\"missing\") = %v, want nil", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,17 @@ func main() {
 		os.Exit(0)
 	}
 
+	// `config` subcommand — persistent config editor (OTEL signals,
+	// resolved-config diagnostic). Consolidates the 7 flags removed from the
+	// root in #87 — the flags that mutate state for FUTURE runs rather than
+	// affecting the current invocation. The transparent-proxy launcher path
+	// below is intentionally flag-driven and bare; persistent state mutation
+	// lives behind this tree.
+	if len(os.Args) >= 2 && os.Args[1] == "config" {
+		runConfigCommand(os.Args[2:])
+		return
+	}
+
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
 		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
@@ -188,8 +199,7 @@ func main() {
 
 	// --- Seed token cache ---
 	tp := NewTokenProvider("", profile)
-	initialToken, err := tp.Token(context.Background())
-	if err != nil {
+	if _, err := tp.Token(context.Background()); err != nil {
 		log.Fatalf("databricks-codex: failed to fetch initial token: %v", err)
 	}
 
@@ -207,41 +217,18 @@ func main() {
 	log.Printf("databricks-codex: gateway URL: %s", gatewayURL)
 
 	// --- OTEL tables ---
-	// Compute the final (otel, metricsTable, logsTable) tuple from flags + state.
-	// Saved state is read once and passed in so the helper is pure & testable.
+	// Compute the final (otel, metricsTable, logsTable) tuple from saved
+	// state. With #87, the persistent-config editor (`databricks-codex config
+	// otel enable/disable`) is the only path that mutates these — the
+	// regular session flow is read-only.
 	saved := loadState()
-	otel, otelMetricsTable, otelLogsTable := resolveOtel(a, saved)
+	otel, otelMetricsTable, otelLogsTable := resolveOtel(saved)
 
-	// Log informational lines and persist any explicit table flags.
-	if !a.OtelMetricsTableSet && otelMetricsTable != "" && otelMetricsTable != "main.codex_telemetry.codex_otel_metrics" {
+	if otelMetricsTable != "" {
 		log.Printf("databricks-codex: using saved otel-metrics-table: %s", otelMetricsTable)
 	}
-	if a.OtelMetricsTableSet {
-		s := loadState()
-		s.OtelMetricsTable = otelMetricsTable
-		if err := saveState(s); err != nil {
-			log.Printf("databricks-codex: failed to save otel-metrics-table: %v", err)
-		} else {
-			log.Printf("databricks-codex: saved otel-metrics-table %q for future sessions", otelMetricsTable)
-		}
-	}
-	if !a.OtelLogsTableSet && otelLogsTable != "" && otelLogsTable != "main.codex_telemetry.codex_otel_logs" {
+	if otelLogsTable != "" {
 		log.Printf("databricks-codex: using saved otel-logs-table: %s", otelLogsTable)
-	}
-	if a.OtelLogsTableSet {
-		s := loadState()
-		s.OtelLogsTable = otelLogsTable
-		if err := saveState(s); err != nil {
-			log.Printf("databricks-codex: failed to save otel-logs-table: %v", err)
-		} else {
-			log.Printf("databricks-codex: saved otel-logs-table %q for future sessions", otelLogsTable)
-		}
-	}
-
-	// --- Print env and exit if requested ---
-	if a.PrintEnv {
-		handlePrintEnv(host, gatewayURL, initialToken, profile, model, otelMetricsTable, otelLogsTable)
-		os.Exit(0)
 	}
 
 	// Verify codex is on PATH before starting proxy (skip in headless mode).
@@ -422,32 +409,31 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath st
 }
 
 // Args holds all parsed databricks-codex flags plus the residual codex args.
+//
+// #87 removed the persistent-config root flags (--otel, --no-otel*,
+// --otel-*-table, --print-env). They live under `databricks-codex config
+// otel {enable|disable}` and `databricks-codex config show` now and have no
+// session-only counterparts — the persistent-config editor IS the surface.
+// The OTEL state still drives the regular session: resolveOtel reads the
+// state file directly to decide whether to emit OTEL endpoints into the
+// proxy + config.toml.
 type Args struct {
-	Verbose             bool
-	Version             bool
-	ShowHelp            bool
-	PrintEnv            bool
-	NoOtel              bool
-	NoOtelMetrics       bool
-	NoOtelLogs          bool
-	OtelLogsTable       string
-	OtelLogsTableSet    bool
-	OtelMetricsTable    string
-	OtelMetricsTableSet bool
-	Upstream            string
-	LogFile             string
-	Profile             string
-	Otel                bool
-	ProxyAPIKey         string
-	TLSCert             string
-	TLSKey              string
-	Model               string
-	ModelSet            bool
-	PortFlag            int
-	Headless            bool
-	IdleTimeout         time.Duration
-	NoUpdateCheck       bool
-	CodexArgs           []string
+	Verbose       bool
+	Version       bool
+	ShowHelp      bool
+	Upstream      string
+	LogFile       string
+	Profile       string
+	ProxyAPIKey   string
+	TLSCert       string
+	TLSKey        string
+	Model         string
+	ModelSet      bool
+	PortFlag      int
+	Headless      bool
+	IdleTimeout   time.Duration
+	NoUpdateCheck bool
+	CodexArgs     []string
 }
 
 // parseArgs separates databricks-codex flags from codex flags.
@@ -490,24 +476,6 @@ func parseArgs(args []string) (*Args, error) {
 
 			if knownFlags[name] {
 				switch name {
-				case "--otel-logs-table":
-					if value != "" {
-						a.OtelLogsTable = value
-						a.OtelLogsTableSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.OtelLogsTable = args[i]
-						a.OtelLogsTableSet = true
-					}
-				case "--otel-metrics-table":
-					if value != "" {
-						a.OtelMetricsTable = value
-						a.OtelMetricsTableSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.OtelMetricsTable = args[i]
-						a.OtelMetricsTableSet = true
-					}
 				case "--upstream":
 					if value != "" {
 						a.Upstream = value
@@ -565,16 +533,6 @@ func parseArgs(args []string) (*Args, error) {
 					a.Version = true
 				case "--help":
 					a.ShowHelp = true
-				case "--print-env":
-					a.PrintEnv = true
-				case "--otel":
-					a.Otel = true
-				case "--no-otel":
-					a.NoOtel = true
-				case "--no-otel-metrics":
-					a.NoOtelMetrics = true
-				case "--no-otel-logs":
-					a.NoOtelLogs = true
 				case "--port":
 					if value != "" {
 						a.PortFlag, _ = strconv.Atoi(value)
@@ -633,15 +591,8 @@ Databricks-Codex Flags:
   --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
   --model string        Model name (saved for future sessions; default: "databricks-gpt-5-5")
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
-  --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
   --log-file string     Write debug logs to a file (combinable with --verbose)
-  --otel                       Enable OpenTelemetry export (metrics + logs)
-  --no-otel                    Disable OpenTelemetry for this session (saved tables preserved)
-  --otel-metrics-table string  Unity Catalog table for OTEL metrics (saved; default: main.codex_telemetry.codex_otel_metrics when --otel is set)
-  --otel-logs-table string     Unity Catalog table for OTEL logs (saved; derived from metrics table when omitted)
-  --no-otel-metrics            Disable metrics for this session (saved table preserved)
-  --no-otel-logs               Disable logs for this session (saved table preserved)
   --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
@@ -653,6 +604,7 @@ Databricks-Codex Flags:
   --help, -h            Show this help message
 
 Subcommands:
+  config                       Persistent config editor (otel enable/disable, show)
   completion <shell>           Generate shell completions (bash, zsh, fish)
   update                       Check for a newer release and print upgrade instructions
   hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
@@ -758,77 +710,37 @@ func resolveProfile(flagValue string, savedValue string) string {
 	return "DEFAULT"
 }
 
-// resolveOtel is the orchestration: given parsed flags + saved state, decide
-// whether OTel is on for this session and which (metrics, logs) tables to use.
+// resolveOtel reads the persistent state and returns the (otel, metrics,
+// logs) tuple the regular session path uses to drive proxy + config.toml
+// patching. Pure function over state — no flag input — because #87 removed
+// the session-time OTEL flags. The persistent-config editor
+// (`databricks-codex config otel enable/disable`) is the only writer; the
+// session is a read-only consumer.
 //
-// Semantics mirror databricks-claude:
+// Semantics:
 //
-//	OTel is "on" if any of: --otel, --otel-metrics-table, --otel-logs-table,
-//	or saved state has any table set — UNLESS --no-otel was passed, which
-//	is the unconditional kill switch.
-//
-//	--no-otel-metrics / --no-otel-logs disable that specific signal for the
-//	current session but leave OTel itself on (so the other signal keeps
-//	exporting) and leave the saved table preference intact.
-//
-// Both returned table strings are empty when their signal is disabled.
-func resolveOtel(a *Args, saved persistentState) (otel bool, metricsTable string, logsTable string) {
-	otel = a.Otel
-	if !otel && !a.NoOtel {
-		if a.OtelMetricsTableSet || a.OtelLogsTableSet || saved.OtelMetricsTable != "" || saved.OtelLogsTable != "" {
-			otel = true
-		}
+//   - A signal is on iff the corresponding *Disabled bit is unset AND the
+//     corresponding table name is non-empty in state.
+//   - Returned table strings are empty when their signal is off (so the
+//     proxy's tomlconfig.Patch removes the [otel] section when both are
+//     empty rather than leaving stale exporter lines).
+//   - OTel as a whole is on iff at least one signal is on.
+func resolveOtel(saved persistentState) (otel bool, metricsTable string, logsTable string) {
+	if !saved.OtelMetricsDisabled && saved.OtelMetricsTable != "" {
+		metricsTable = saved.OtelMetricsTable
 	}
-	if a.NoOtel {
-		otel = false
+	if !saved.OtelLogsDisabled && saved.OtelLogsTable != "" {
+		logsTable = saved.OtelLogsTable
 	}
-
-	if !a.NoOtelMetrics {
-		metricsTable = resolveOtelMetricsTable(a.OtelMetricsTable, a.OtelMetricsTableSet, saved.OtelMetricsTable, otel)
-	}
-	if !a.NoOtelLogs {
-		logsTable = resolveOtelLogsTable(a.OtelLogsTable, a.OtelLogsTableSet, saved.OtelLogsTable, metricsTable, otel)
-	}
+	otel = metricsTable != "" || logsTable != ""
 	return otel, metricsTable, logsTable
-}
-
-// resolveOtelLogsTable returns the OTEL logs table using the resolution chain:
-// explicit flag → saved state → derive-from-metrics-table → default.
-// Returns empty string when otel is disabled.
-func resolveOtelLogsTable(flagValue string, flagSet bool, savedValue string, metricsTable string, otel bool) string {
-	if !otel {
-		return ""
-	}
-	if flagSet && flagValue != "" {
-		return flagValue
-	}
-	if savedValue != "" {
-		return savedValue
-	}
-	if metricsTable != "" {
-		return deriveLogsTable(metricsTable)
-	}
-	return "main.codex_telemetry.codex_otel_logs"
-}
-
-// resolveOtelMetricsTable returns the OTEL metrics table using the resolution chain:
-// explicit flag → saved state → default. Returns empty string when otel is disabled.
-func resolveOtelMetricsTable(flagValue string, flagSet bool, savedValue string, otel bool) string {
-	if !otel {
-		return ""
-	}
-	if flagSet && flagValue != "" {
-		return flagValue
-	}
-	if savedValue != "" {
-		return savedValue
-	}
-	return "main.codex_telemetry.codex_otel_metrics"
 }
 
 // deriveLogsTable derives the OTEL logs table name from a metrics table name.
 // If the metrics table ends with "_otel_metrics", replace that suffix with "_otel_logs".
-// Otherwise append "_otel_logs". Ported from databricks-claude/main.go.
+// Otherwise append "_otel_logs". Ported from databricks-claude/main.go and
+// kept exported (within-package) so cli_config.go's resolver can reuse it
+// for the `config otel enable --metrics-table` derivation.
 func deriveLogsTable(metricsTable string) string {
 	if metricsTable == "" {
 		return ""

--- a/main.go
+++ b/main.go
@@ -33,7 +33,19 @@ func main() {
 	// completion <shell> — must be the very first check, before any flag parsing,
 	// auth, or state loading. Safe to call in the Homebrew install sandbox.
 	if len(os.Args) >= 2 && os.Args[1] == "completion" {
-		completion.Run(os.Args[2:], flagDefs, "databricks-codex")
+		completion.Run(os.Args[2:], flagDefs, "databricks-codex", knownSubcommands...)
+		os.Exit(0)
+	}
+
+	// hooks <subcommand> — handled before auth/state setup since
+	// session-start is hot-path (called by every codex SessionStart) and
+	// install/uninstall must work in environments where the proxy is not
+	// yet configured. The dispatcher in hooks_cmd.go owns flag parsing.
+	if len(os.Args) >= 2 && os.Args[1] == "hooks" {
+		if err := runHooksCommand(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
@@ -77,37 +89,6 @@ func main() {
 
 	if a.Version {
 		fmt.Printf("databricks-codex %s\n", Version)
-		os.Exit(0)
-	}
-
-	// --- Hook lifecycle commands (handled before auth/config setup) ---
-	if a.InstallHooksFlag || a.UninstallHooksFlag {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatalf("databricks-codex: cannot determine home dir: %v", err)
-		}
-		hp := filepath.Join(homeDir, ".codex", "hooks.json")
-		if a.InstallHooksFlag {
-			if err := installHooks(hp); err != nil {
-				log.Fatalf("databricks-codex: --install-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-codex: hooks installed — SessionStart hook added to ~/.codex/hooks.json")
-		} else {
-			if err := uninstallHooks(hp); err != nil {
-				log.Fatalf("databricks-codex: --uninstall-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-codex: hooks removed from ~/.codex/hooks.json")
-		}
-		os.Exit(0)
-	}
-
-	// --- Headless hook command (called by installed hooks, not by end users) ---
-	if a.HeadlessEnsureFlag {
-		state := loadState()
-		port := resolvePort(a.PortFlag, state)
-		if err := headlessEnsure(port); err != nil {
-			log.Fatalf("databricks-codex: headless ensure failed: %v", err)
-		}
 		os.Exit(0)
 	}
 
@@ -465,9 +446,6 @@ type Args struct {
 	PortFlag            int
 	Headless            bool
 	IdleTimeout         time.Duration
-	InstallHooksFlag    bool
-	UninstallHooksFlag  bool
-	HeadlessEnsureFlag  bool
 	NoUpdateCheck       bool
 	CodexArgs           []string
 }
@@ -617,12 +595,6 @@ func parseArgs(args []string) (*Args, error) {
 						return nil, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
 					}
 					a.IdleTimeout = d
-				case "--install-hooks":
-					a.InstallHooksFlag = true
-				case "--uninstall-hooks":
-					a.UninstallHooksFlag = true
-				case "--headless-ensure":
-					a.HeadlessEnsureFlag = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:
@@ -675,10 +647,7 @@ Databricks-Codex Flags:
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Fixed proxy port (default: 49154, saved to state)
   --headless                Start proxy without launching codex (for IDE extensions)
-  --headless-ensure         Start proxy if not running (called by SessionStart hook)
   --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables)
-  --install-hooks           Install SessionStart hook into ~/.codex/hooks.json
-  --uninstall-hooks         Remove databricks-codex hooks from ~/.codex/hooks.json
   --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
@@ -686,6 +655,7 @@ Databricks-Codex Flags:
 Subcommands:
   completion <shell>           Generate shell completions (bash, zsh, fish)
   update                       Check for a newer release and print upgrade instructions
+  hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
 
 ────────────────────────────────────────────────────────────────────────────────
 Codex CLI Options:

--- a/main.go
+++ b/main.go
@@ -60,6 +60,20 @@ func main() {
 		return
 	}
 
+	// `serve` subcommand — runs the proxy in headless mode. Consolidates the
+	// legacy --headless and --idle-timeout root flags removed in #89.
+	// Dispatched before parseArgs so the serve flag set is parsed by the
+	// serve subtree (not by the root parser, which no longer recognises
+	// --idle-timeout). The runner ends up calling runProxyMode with
+	// Headless=true — same launcher the legacy --headless path used.
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if err := runServeCommand(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
 		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
@@ -103,6 +117,28 @@ func main() {
 		os.Exit(0)
 	}
 
+	runProxyMode(a)
+}
+
+// runProxyMode is the shared launcher for both the transparent-wrapper path
+// (databricks-codex with no subcommand → spawn codex as a child) and the
+// headless path (databricks-codex serve → keep the proxy alive without a
+// child). The two paths converge on the same Args struct: the serve
+// dispatcher (runServeCommand) constructs Args with Headless=true and the
+// resolved IdleTimeout, while the wrapper path leaves both at their zero
+// values.
+//
+// The Headless/IdleTimeout fields are no longer set by parseArgs (the legacy
+// --headless / --idle-timeout root flags were removed in #89); they are
+// populated only by the serve dispatcher. Treating them as Args fields keeps
+// runProxyMode's signature stable and makes the serve test surface a simple
+// "spy on the Args struct that runServeCommand constructs" check (see
+// serve_cmd_test.go).
+//
+// Exits the process directly in the codex-launch path (with codex's exit
+// code); returns normally in the headless path so the serve dispatcher's
+// caller can os.Exit(0).
+func runProxyMode(a *Args) {
 	// Default: discard all logs (silent wrapper).
 	log.SetOutput(io.Discard)
 
@@ -417,6 +453,14 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath st
 // The OTEL state still drives the regular session: resolveOtel reads the
 // state file directly to decide whether to emit OTEL endpoints into the
 // proxy + config.toml.
+//
+// #89 removed the legacy --headless and --idle-timeout root flags. Their
+// effect now lives behind the `serve` subcommand. The Headless and
+// IdleTimeout fields stay on this struct because they are inputs to
+// runProxyMode — set by runServeCommand (serve_cmd.go) when the user
+// invokes `databricks-codex serve`. parseArgs never sets them; the
+// transparent-wrapper path leaves both at zero (Headless=false,
+// IdleTimeout=0) and runProxyMode skips the headless branches.
 type Args struct {
 	Verbose       bool
 	Version       bool
@@ -430,17 +474,21 @@ type Args struct {
 	Model         string
 	ModelSet      bool
 	PortFlag      int
-	Headless      bool
-	IdleTimeout   time.Duration
+	Headless      bool          // set by runServeCommand only (#89)
+	IdleTimeout   time.Duration // set by runServeCommand only (#89)
 	NoUpdateCheck bool
 	CodexArgs     []string
 }
 
-// parseArgs separates databricks-codex flags from codex flags.
+// parseArgs separates databricks-codex flags from codex flags. Recognises
+// only the root-flag set declared on rootCommand (commands.go); the legacy
+// --headless and --idle-timeout flags removed in #89 are intentionally NOT
+// recognised here — they will fall through to CodexArgs and be forwarded to
+// the wrapped codex binary, where they were never valid (codex will reject
+// them with its own error). Users should migrate to `databricks-codex serve
+// [--idle-timeout D]`.
 func parseArgs(args []string) (*Args, error) {
-	a := &Args{
-		IdleTimeout: 30 * time.Minute, // default
-	}
+	a := &Args{}
 
 	// knownFlags is defined at package level in completion_flags.go,
 	// derived from flagDefs so completions and parsing stay in sync.
@@ -540,19 +588,6 @@ func parseArgs(args []string) (*Args, error) {
 						i++
 						a.PortFlag, _ = strconv.Atoi(args[i])
 					}
-				case "--headless":
-					a.Headless = true
-				case "--idle-timeout":
-					raw := value
-					if raw == "" && i+1 < len(args) {
-						i++
-						raw = args[i]
-					}
-					d, err := time.ParseDuration(raw)
-					if err != nil {
-						return nil, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
-					}
-					a.IdleTimeout = d
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:
@@ -597,9 +632,7 @@ Databricks-Codex Flags:
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Fixed proxy port (default: 49154, saved to state)
-  --headless                Start proxy without launching codex (for IDE extensions)
-  --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables)
-  --no-update-check            Skip the automatic update check on startup
+  --no-update-check         Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
 
@@ -608,6 +641,7 @@ Subcommands:
   completion <shell>           Generate shell completions (bash, zsh, fish)
   update                       Check for a newer release and print upgrade instructions
   hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
+  serve [flags]                Run the proxy in headless mode (consolidates the deleted root flags)
 
 ────────────────────────────────────────────────────────────────────────────────
 Codex CLI Options:

--- a/main.go
+++ b/main.go
@@ -625,6 +625,15 @@ func parseArgs(args []string) (*Args, error) {
 					a.HeadlessEnsureFlag = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
+				default:
+					// A name in knownFlags must have a corresponding case
+					// above; this arm catches the case where rootCommand
+					// declares a new flag but parseArgs hasn't been updated.
+					// Loud failure beats silent passthrough — the bidirectional
+					// parity test in main_test.go also detects this drift,
+					// but a runtime check catches it for any caller path the
+					// test doesn't exercise.
+					return nil, fmt.Errorf("internal: %s is a known flag but parseArgs has no case for it", name)
 				}
 				i++
 				continue

--- a/main_test.go
+++ b/main_test.go
@@ -974,6 +974,53 @@ func TestKnownFlagsCoverAllFlagDefs(t *testing.T) {
 	}
 }
 
+// TestRootTreeFlagsAreParseRecognised verifies that every flag declared on
+// rootCommand (the source of truth for the binary's CLI surface) is actually
+// handled by parseArgs. Catches the case where a flag is added to the tree
+// in commands.go but the matching switch case is forgotten in main.go's
+// parseArgs — the explicit default arm in parseArgs returns an error in
+// that scenario, which this test surfaces as a per-flag failure.
+//
+// This is the "tree → parser" half of the bidirectional parity check;
+// TestParseArgsRecognisedFlagsAreInTree below covers the inverse direction.
+func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
+	for _, f := range rootCommand.AllFlags() {
+		var args []string
+		if f.TakesArg {
+			value := "value"
+			// --idle-timeout is the only flag with strict parsing; supply
+			// a valid duration so the test exercises the case arm itself
+			// rather than the duration-parse error path.
+			if f.Name == "idle-timeout" {
+				value = "30s"
+			}
+			args = []string{"--" + f.Name, value}
+		} else {
+			args = []string{"--" + f.Name}
+		}
+		if _, err := parseArgs(args); err != nil {
+			t.Errorf("parseArgs(%v) returned error %v — flag %q is declared on rootCommand but parseArgs has no case for it", args, err, f.Name)
+		}
+	}
+}
+
+// TestParseArgsRecognisedFlagsAreInTree is the inverse parity check: every
+// flag the parser thinks it owns (knownFlags) must appear in rootCommand.
+// Since knownFlags is now derived from rootCommand, this is structurally
+// guaranteed — the test is here to document the contract and to fail
+// loudly if a future refactor decouples the two.
+func TestParseArgsRecognisedFlagsAreInTree(t *testing.T) {
+	treeNames := map[string]bool{}
+	for _, f := range rootCommand.AllFlags() {
+		treeNames["--"+f.Name] = true
+	}
+	for name := range knownFlags {
+		if !treeNames[name] {
+			t.Errorf("knownFlags contains %q but it is not declared on rootCommand", name)
+		}
+	}
+}
+
 // TestResolveModel_DefaultIsGpt5_5 locks the built-in default model against
 // silent drift. When no flag is passed and saved state is empty, resolveModel
 // must return databricks-gpt-5-5. Bumping the default requires updating this

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // mustParseArgs is a test helper that calls parseArgs and fails the test on error.
@@ -132,8 +131,15 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 	if len(a.CodexArgs) != 0 {
 		t.Errorf("expected no CodexArgs, got %v", a.CodexArgs)
 	}
-	if a.IdleTimeout != 30*time.Minute {
-		t.Errorf("expected default IdleTimeout=30m, got %v", a.IdleTimeout)
+	// #89 removed the --idle-timeout root flag; parseArgs no longer
+	// initialises Args.IdleTimeout. The default 30m default is now
+	// applied by buildServeArgs (serve_cmd.go); see
+	// TestBuildServeArgs_DefaultIdleTimeout.
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected zero IdleTimeout from parseArgs (no longer parsed), got %v", a.IdleTimeout)
+	}
+	if a.Headless {
+		t.Error("expected Headless=false from parseArgs (no longer parsed; set only by runServeCommand)")
 	}
 }
 
@@ -213,52 +219,14 @@ func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
 }
 
 // --- --idle-timeout strict parsing tests ---
-
-func TestParseArgs_IdleTimeout_Seconds(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "30s"})
-	if a.IdleTimeout != 30*time.Second {
-		t.Errorf("expected 30s, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Minutes(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "5m"})
-	if a.IdleTimeout != 5*time.Minute {
-		t.Errorf("expected 5m, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Hours(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "1h"})
-	if a.IdleTimeout != time.Hour {
-		t.Errorf("expected 1h, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Equals(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout=2h30m"})
-	if a.IdleTimeout != 2*time.Hour+30*time.Minute {
-		t.Errorf("expected 2h30m, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_BareIntRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout", "30"}); err == nil {
-		t.Error("expected error for bare int --idle-timeout, got nil")
-	}
-}
-
-func TestParseArgs_IdleTimeout_GarbageRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout", "30mins"}); err == nil {
-		t.Error("expected error for '30mins' --idle-timeout, got nil")
-	}
-}
-
-func TestParseArgs_IdleTimeout_EmptyRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout="}); err == nil {
-		t.Error("expected error for empty --idle-timeout, got nil")
-	}
-}
+//
+// #89 removed --idle-timeout from the root flag set; parseArgs no longer
+// recognises it. The duration-parsing strict-validation surface (seconds /
+// minutes / hours / equals / bare-int rejected / garbage rejected / empty
+// rejected) lives on the serve subcommand now and is exercised by
+// TestBuildServeArgs_IdleTimeout* in serve_cmd_test.go. The legacy
+// --idle-timeout root flag falls through to CodexArgs (verified by
+// TestParseArgs_Table's "legacy --idle-timeout passes through" case).
 
 // Table-driven comprehensive test for parseArgs.
 func TestParseArgs_Table(t *testing.T) {
@@ -280,7 +248,6 @@ func TestParseArgs_Table(t *testing.T) {
 		{name: "--profile=value", args: []string{"--profile=aidev"}, want: Args{Profile: "aidev"}},
 		{name: "--model", args: []string{"--model", "my-model"}, want: Args{Model: "my-model", ModelSet: true}},
 		{name: "--port", args: []string{"--port", "9999"}, want: Args{PortFlag: 9999}},
-		{name: "--headless", args: []string{"--headless"}, want: Args{Headless: true}},
 		{name: "--no-update-check", args: []string{"--no-update-check"}, want: Args{NoUpdateCheck: true}},
 		{
 			// #88 removed --install-hooks; the legacy flag is no longer in
@@ -298,6 +265,22 @@ func TestParseArgs_Table(t *testing.T) {
 			name: "legacy --headless-ensure now passes through to codex",
 			args: []string{"--headless-ensure"},
 			want: Args{CodexArgs: []string{"--headless-ensure"}},
+		},
+		{
+			// #89 removed --headless; the legacy flag is no longer in
+			// knownFlags, so parseArgs forwards it to codex unchanged.
+			// Users should migrate to `databricks-codex serve`.
+			name: "legacy --headless now passes through to codex",
+			args: []string{"--headless"},
+			want: Args{CodexArgs: []string{"--headless"}},
+		},
+		{
+			// #89 removed --idle-timeout. parseArgs forwards both the
+			// flag name and its value as separate codex args (it has no
+			// way to know the flag took a value).
+			name: "legacy --idle-timeout now passes through to codex",
+			args: []string{"--idle-timeout", "5m"},
+			want: Args{CodexArgs: []string{"--idle-timeout", "5m"}},
 		},
 	}
 
@@ -512,10 +495,32 @@ func TestParseArgs_ProfileEquals(t *testing.T) {
 	}
 }
 
-func TestParseArgs_Headless(t *testing.T) {
+// TestParseArgs_LegacyHeadlessPassthrough locks the breaking surface from
+// #89: the deleted --headless root flag must NOT be recognised by parseArgs;
+// it forwards to CodexArgs unchanged. Catches the regression where someone
+// re-adds the case in parseArgs without bringing back the flag.
+func TestParseArgs_LegacyHeadlessPassthrough(t *testing.T) {
 	a := mustParseArgs(t, []string{"--headless"})
-	if !a.Headless {
-		t.Error("expected Headless=true for --headless")
+	if a.Headless {
+		t.Error("Args.Headless must NOT be set by parseArgs after #89; only runServeCommand sets it")
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--headless" {
+		t.Errorf("legacy --headless must pass through to CodexArgs, got %v", a.CodexArgs)
+	}
+}
+
+// TestParseArgs_LegacyIdleTimeoutPassthrough is the symmetric check for
+// the deleted --idle-timeout root flag.
+func TestParseArgs_LegacyIdleTimeoutPassthrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--idle-timeout", "5m"})
+	if a.IdleTimeout != 0 {
+		t.Errorf("Args.IdleTimeout must NOT be set by parseArgs after #89, got %v", a.IdleTimeout)
+	}
+	// The flag name and its value both fall through as positional args
+	// because parseArgs has no metadata to tell it the legacy flag took a
+	// value. Both tokens land in CodexArgs.
+	if len(a.CodexArgs) != 2 || a.CodexArgs[0] != "--idle-timeout" || a.CodexArgs[1] != "5m" {
+		t.Errorf("legacy --idle-timeout must pass through to CodexArgs, got %v", a.CodexArgs)
 	}
 }
 
@@ -533,11 +538,26 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	// Legacy hook flags (--install-hooks / --uninstall-hooks /
 	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
 	// OTEL/--print-env flags moved to `config otel`/`config show` in #87.
-	// The help text now lists `config` and `hooks` instead.
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--headless", "--idle-timeout", "--no-update-check", "--version", "--help", "config", "hooks"}
+	// --headless / --idle-timeout were lifted to the `serve` subcommand in
+	// #89. The help text now lists `config`, `hooks`, and `serve` instead.
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--no-update-check", "--version", "--help", "config", "hooks", "serve"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestHandleHelp_LegacyHeadlessFlagsAbsent locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear in the
+// root help text. If a future refactor re-adds them, this test fires.
+func TestHandleHelp_LegacyHeadlessFlagsAbsent(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, flag := range []string{"--headless", "--idle-timeout"} {
+		if strings.Contains(out, flag) {
+			t.Errorf("root help still mentions %q after #89 migration; users will discover the dead flag", flag)
 		}
 	}
 }
@@ -834,14 +854,7 @@ func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
 	for _, f := range rootCommand.AllFlags() {
 		var args []string
 		if f.TakesArg {
-			value := "value"
-			// --idle-timeout is the only flag with strict parsing; supply
-			// a valid duration so the test exercises the case arm itself
-			// rather than the duration-parse error path.
-			if f.Name == "idle-timeout" {
-				value = "30s"
-			}
-			args = []string{"--" + f.Name, value}
+			args = []string{"--" + f.Name, "value"}
 		} else {
 			args = []string{"--" + f.Name}
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,20 @@ func mustParseArgs(t *testing.T, args []string) *Args {
 	return a
 }
 
+// equalStringSlice reports whether a and b have the same length and same
+// elements in order. nil and empty slices are treated equal.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
@@ -342,10 +356,24 @@ func TestParseArgs_Table(t *testing.T) {
 		{name: "--model", args: []string{"--model", "my-model"}, want: Args{Model: "my-model", ModelSet: true}},
 		{name: "--port", args: []string{"--port", "9999"}, want: Args{PortFlag: 9999}},
 		{name: "--headless", args: []string{"--headless"}, want: Args{Headless: true}},
-		{name: "--install-hooks", args: []string{"--install-hooks"}, want: Args{InstallHooksFlag: true}},
-		{name: "--uninstall-hooks", args: []string{"--uninstall-hooks"}, want: Args{UninstallHooksFlag: true}},
-		{name: "--headless-ensure", args: []string{"--headless-ensure"}, want: Args{HeadlessEnsureFlag: true}},
 		{name: "--no-update-check", args: []string{"--no-update-check"}, want: Args{NoUpdateCheck: true}},
+		{
+			// #88 removed --install-hooks; the legacy flag is no longer in
+			// knownFlags, so parseArgs forwards it to codex unchanged.
+			name: "legacy --install-hooks now passes through to codex",
+			args: []string{"--install-hooks"},
+			want: Args{CodexArgs: []string{"--install-hooks"}},
+		},
+		{
+			name: "legacy --uninstall-hooks now passes through to codex",
+			args: []string{"--uninstall-hooks"},
+			want: Args{CodexArgs: []string{"--uninstall-hooks"}},
+		},
+		{
+			name: "legacy --headless-ensure now passes through to codex",
+			args: []string{"--headless-ensure"},
+			want: Args{CodexArgs: []string{"--headless-ensure"}},
+		},
 	}
 
 	for _, tc := range tests {
@@ -393,17 +421,11 @@ func TestParseArgs_Table(t *testing.T) {
 			if got.Headless != tc.want.Headless {
 				t.Errorf("Headless: got %v, want %v", got.Headless, tc.want.Headless)
 			}
-			if got.InstallHooksFlag != tc.want.InstallHooksFlag {
-				t.Errorf("InstallHooksFlag: got %v, want %v", got.InstallHooksFlag, tc.want.InstallHooksFlag)
-			}
-			if got.UninstallHooksFlag != tc.want.UninstallHooksFlag {
-				t.Errorf("UninstallHooksFlag: got %v, want %v", got.UninstallHooksFlag, tc.want.UninstallHooksFlag)
-			}
-			if got.HeadlessEnsureFlag != tc.want.HeadlessEnsureFlag {
-				t.Errorf("HeadlessEnsureFlag: got %v, want %v", got.HeadlessEnsureFlag, tc.want.HeadlessEnsureFlag)
-			}
 			if got.NoUpdateCheck != tc.want.NoUpdateCheck {
 				t.Errorf("NoUpdateCheck: got %v, want %v", got.NoUpdateCheck, tc.want.NoUpdateCheck)
+			}
+			if !equalStringSlice(got.CodexArgs, tc.want.CodexArgs) {
+				t.Errorf("CodexArgs: got %v, want %v", got.CodexArgs, tc.want.CodexArgs)
 			}
 		})
 	}
@@ -599,7 +621,10 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--headless-ensure", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--no-update-check", "--version", "--help"}
+	// Legacy hook flags (--install-hooks / --uninstall-hooks /
+	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
+	// help text now lists `hooks` instead.
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--idle-timeout", "--no-update-check", "--version", "--help", "hooks"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)

--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,7 @@ func TestParseArgs_HelpLong(t *testing.T) {
 	if !a.ShowHelp {
 		t.Error("expected ShowHelp=true for --help")
 	}
-	if a.Verbose || a.Version || a.PrintEnv || a.NoOtel || a.Otel || a.Upstream != "" || a.LogFile != "" || a.Profile != "" || len(a.CodexArgs) != 0 {
+	if a.Verbose || a.Version || a.Upstream != "" || a.LogFile != "" || a.Profile != "" || len(a.CodexArgs) != 0 {
 		t.Error("unexpected non-default values alongside --help")
 	}
 }
@@ -52,13 +52,6 @@ func TestParseArgs_HelpShort(t *testing.T) {
 	a := mustParseArgs(t, []string{"-h"})
 	if !a.ShowHelp {
 		t.Error("expected ShowHelp=true for -h")
-	}
-}
-
-func TestParseArgs_PrintEnv(t *testing.T) {
-	a := mustParseArgs(t, []string{"--print-env"})
-	if !a.PrintEnv {
-		t.Error("expected PrintEnv=true for --print-env")
 	}
 }
 
@@ -111,73 +104,9 @@ func TestParseArgs_UpstreamEquals(t *testing.T) {
 	}
 }
 
-func TestParseArgs_NoOtel(t *testing.T) {
-	a := mustParseArgs(t, []string{"--no-otel"})
-	if !a.NoOtel {
-		t.Error("expected NoOtel=true for --no-otel")
-	}
-	if len(a.CodexArgs) != 0 {
-		t.Errorf("expected no CodexArgs, got %v", a.CodexArgs)
-	}
-}
-
-func TestParseArgs_OtelLogsTable(t *testing.T) {
-	a := mustParseArgs(t, []string{"--otel-logs-table", "main.custom.logs"})
-	if !a.OtelLogsTableSet {
-		t.Error("expected OtelLogsTableSet=true when --otel-logs-table is passed")
-	}
-	if a.OtelLogsTable != "main.custom.logs" {
-		t.Errorf("expected OtelLogsTable=%q, got %q", "main.custom.logs", a.OtelLogsTable)
-	}
-}
-
-func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	a := mustParseArgs(t, []string{})
-	if a.OtelLogsTableSet {
-		t.Error("expected OtelLogsTableSet=false when --otel-logs-table is not passed")
-	}
-	_ = a.OtelLogsTable
-}
-
-func TestParseArgs_OtelMetricsTable(t *testing.T) {
-	a := mustParseArgs(t, []string{"--otel-metrics-table", "main.custom.metrics"})
-	if !a.OtelMetricsTableSet {
-		t.Error("expected OtelMetricsTableSet=true when --otel-metrics-table is passed")
-	}
-	if a.OtelMetricsTable != "main.custom.metrics" {
-		t.Errorf("expected OtelMetricsTable=%q, got %q", "main.custom.metrics", a.OtelMetricsTable)
-	}
-}
-
-func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	a := mustParseArgs(t, []string{"--otel-metrics-table=cat.schema.tbl"})
-	if !a.OtelMetricsTableSet {
-		t.Error("expected OtelMetricsTableSet=true for --otel-metrics-table=value form")
-	}
-	if a.OtelMetricsTable != "cat.schema.tbl" {
-		t.Errorf("expected OtelMetricsTable=%q, got %q", "cat.schema.tbl", a.OtelMetricsTable)
-	}
-}
-
-func TestParseArgs_NoOtelMetrics(t *testing.T) {
-	a := mustParseArgs(t, []string{"--no-otel-metrics"})
-	if !a.NoOtelMetrics {
-		t.Error("expected NoOtelMetrics=true for --no-otel-metrics")
-	}
-	if a.NoOtelLogs || a.NoOtel {
-		t.Error("--no-otel-metrics should not set NoOtelLogs or NoOtel")
-	}
-}
-
-func TestParseArgs_NoOtelLogs(t *testing.T) {
-	a := mustParseArgs(t, []string{"--no-otel-logs"})
-	if !a.NoOtelLogs {
-		t.Error("expected NoOtelLogs=true for --no-otel-logs")
-	}
-	if a.NoOtelMetrics || a.NoOtel {
-		t.Error("--no-otel-logs should not set NoOtelMetrics or NoOtel")
-	}
-}
+// #87 removed --no-otel*/--otel-*-table; coverage moved to TestResolveConfigOTEL_*
+// (state-driven resolver) and TestRootTreeFlagsAreParseRecognised (shrink-side
+// of the bidirectional parity check).
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
 	a := mustParseArgs(t, []string{"--unknown"})
@@ -188,7 +117,7 @@ func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
 	a := mustParseArgs(t, []string{})
-	if a.Verbose || a.Version || a.ShowHelp || a.PrintEnv || a.NoOtel || a.Otel {
+	if a.Verbose || a.Version || a.ShowHelp {
 		t.Error("expected all bool flags false for empty args")
 	}
 	if a.Upstream != "" {
@@ -340,19 +269,15 @@ func TestParseArgs_Table(t *testing.T) {
 	}{
 		{name: "--help sets showHelp", args: []string{"--help"}, want: Args{ShowHelp: true}},
 		{name: "-h sets showHelp", args: []string{"-h"}, want: Args{ShowHelp: true}},
-		{name: "--print-env sets printEnv", args: []string{"--print-env"}, want: Args{PrintEnv: true}},
 		{name: "--version sets version", args: []string{"--version"}, want: Args{Version: true}},
 		{name: "--verbose sets verbose", args: []string{"--verbose"}, want: Args{Verbose: true}},
 		{name: "-v sets verbose", args: []string{"-v"}, want: Args{Verbose: true}},
 		{name: "--log-file sets logFile", args: []string{"--log-file", "/tmp/test.log"}, want: Args{LogFile: "/tmp/test.log"}},
 		{name: "--log-file=value", args: []string{"--log-file=/tmp/test.log"}, want: Args{LogFile: "/tmp/test.log"}},
 		{name: "--upstream sets upstream", args: []string{"--upstream", "https://gw.example.com"}, want: Args{Upstream: "https://gw.example.com"}},
-		{name: "--no-otel sets noOtel", args: []string{"--no-otel"}, want: Args{NoOtel: true}},
 		{name: "empty args all defaults", args: []string{}, want: Args{}},
 		{name: "--profile", args: []string{"--profile", "aidev"}, want: Args{Profile: "aidev"}},
 		{name: "--profile=value", args: []string{"--profile=aidev"}, want: Args{Profile: "aidev"}},
-		{name: "--otel", args: []string{"--otel"}, want: Args{Otel: true}},
-		{name: "--otel and --no-otel", args: []string{"--otel", "--no-otel"}, want: Args{Otel: true, NoOtel: true}},
 		{name: "--model", args: []string{"--model", "my-model"}, want: Args{Model: "my-model", ModelSet: true}},
 		{name: "--port", args: []string{"--port", "9999"}, want: Args{PortFlag: 9999}},
 		{name: "--headless", args: []string{"--headless"}, want: Args{Headless: true}},
@@ -391,12 +316,6 @@ func TestParseArgs_Table(t *testing.T) {
 			if got.ShowHelp != tc.want.ShowHelp {
 				t.Errorf("ShowHelp: got %v, want %v", got.ShowHelp, tc.want.ShowHelp)
 			}
-			if got.PrintEnv != tc.want.PrintEnv {
-				t.Errorf("PrintEnv: got %v, want %v", got.PrintEnv, tc.want.PrintEnv)
-			}
-			if got.NoOtel != tc.want.NoOtel {
-				t.Errorf("NoOtel: got %v, want %v", got.NoOtel, tc.want.NoOtel)
-			}
 			if got.Upstream != tc.want.Upstream {
 				t.Errorf("Upstream: got %q, want %q", got.Upstream, tc.want.Upstream)
 			}
@@ -405,9 +324,6 @@ func TestParseArgs_Table(t *testing.T) {
 			}
 			if got.Profile != tc.want.Profile {
 				t.Errorf("Profile: got %q, want %q", got.Profile, tc.want.Profile)
-			}
-			if got.Otel != tc.want.Otel {
-				t.Errorf("Otel: got %v, want %v", got.Otel, tc.want.Otel)
 			}
 			if got.Model != tc.want.Model {
 				t.Errorf("Model: got %q, want %q", got.Model, tc.want.Model)
@@ -554,12 +470,12 @@ func TestHandleHelp_ContainsDatabricksCodex(t *testing.T) {
 	}
 }
 
-func TestHandleHelp_ContainsPrintEnvFlag(t *testing.T) {
+func TestHandleHelp_ContainsConfigSubcommand(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	if !strings.Contains(out, "--print-env") {
-		t.Errorf("expected help output to contain '--print-env', got:\n%s", out)
+	if !strings.Contains(out, "config") {
+		t.Errorf("expected help output to advertise the config subcommand, got:\n%s", out)
 	}
 }
 
@@ -610,24 +526,30 @@ func TestParseArgs_NoUpdateCheck(t *testing.T) {
 	}
 }
 
-func TestParseArgs_Otel(t *testing.T) {
-	a := mustParseArgs(t, []string{"--otel"})
-	if !a.Otel {
-		t.Error("expected Otel=true for --otel")
-	}
-}
-
 func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
 	// Legacy hook flags (--install-hooks / --uninstall-hooks /
 	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
-	// help text now lists `hooks` instead.
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--no-otel", "--otel-logs-table", "--port", "--headless", "--idle-timeout", "--no-update-check", "--version", "--help", "hooks"}
+	// OTEL/--print-env flags moved to `config otel`/`config show` in #87.
+	// The help text now lists `config` and `hooks` instead.
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--headless", "--idle-timeout", "--no-update-check", "--version", "--help", "config", "hooks"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+func TestHandleHelp_LegacyOtelFlagsAbsent(t *testing.T) {
+	// Locks the breaking surface: #87 removed these from the root.
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, flag := range []string{"--otel", "--no-otel", "--no-otel-metrics", "--no-otel-logs", "--otel-metrics-table", "--otel-logs-table", "--print-env"} {
+		if strings.Contains(out, flag) {
+			t.Errorf("root help still mentions %q after #87 migration; users will discover the dead flag", flag)
 		}
 	}
 }
@@ -641,61 +563,11 @@ func TestHandleHelp_ContainsVersion(t *testing.T) {
 	}
 }
 
-// --- resolveOtelLogsTable / resolveOtelMetricsTable / deriveLogsTable tests ---
-
-func TestResolveOtelLogsTable(t *testing.T) {
-	tests := []struct {
-		name         string
-		flagValue    string
-		flagSet      bool
-		savedValue   string
-		metricsTable string
-		otel         bool
-		want         string
-	}{
-		{name: "otel disabled returns empty", otel: false, savedValue: "saved.table", want: ""},
-		{name: "flag set with value wins", flagValue: "custom.db.table", flagSet: true, otel: true, want: "custom.db.table"},
-		{name: "flag set wins over saved", flagValue: "flag.table", flagSet: true, savedValue: "saved.table", otel: true, want: "flag.table"},
-		{name: "saved value used when flag not set", flagSet: false, savedValue: "saved.table", otel: true, want: "saved.table"},
-		{name: "derives from metrics when no flag and no saved", flagSet: false, metricsTable: "main.tel.codex_otel_metrics", otel: true, want: "main.tel.codex_otel_logs"},
-		{name: "default when no flag, saved, or metrics", flagSet: false, otel: true, want: "main.codex_telemetry.codex_otel_logs"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveOtelLogsTable(tc.flagValue, tc.flagSet, tc.savedValue, tc.metricsTable, tc.otel)
-			if got != tc.want {
-				t.Errorf("resolveOtelLogsTable(%q, %v, %q, %q, %v) = %q, want %q",
-					tc.flagValue, tc.flagSet, tc.savedValue, tc.metricsTable, tc.otel, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestResolveOtelMetricsTable(t *testing.T) {
-	tests := []struct {
-		name       string
-		flagValue  string
-		flagSet    bool
-		savedValue string
-		otel       bool
-		want       string
-	}{
-		{name: "otel disabled returns empty", otel: false, savedValue: "saved.metrics", want: ""},
-		{name: "flag set wins", flagValue: "flag.metrics", flagSet: true, savedValue: "saved.metrics", otel: true, want: "flag.metrics"},
-		{name: "saved used when flag not set", flagSet: false, savedValue: "saved.metrics", otel: true, want: "saved.metrics"},
-		{name: "default when nothing set", flagSet: false, otel: true, want: "main.codex_telemetry.codex_otel_metrics"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveOtelMetricsTable(tc.flagValue, tc.flagSet, tc.savedValue, tc.otel)
-			if got != tc.want {
-				t.Errorf("resolveOtelMetricsTable(%q, %v, %q, %v) = %q, want %q",
-					tc.flagValue, tc.flagSet, tc.savedValue, tc.otel, got, tc.want)
-			}
-		})
-	}
-}
+// --- deriveLogsTable test ---
+//
+// resolveOtelLogsTable / resolveOtelMetricsTable were inlined into the
+// `config otel enable` resolver in #87; their unit tests folded into
+// TestResolveConfigOTEL_OrchestrationMatrix in cli_config_test.go.
 
 func TestDeriveLogsTable(t *testing.T) {
 	tests := []struct {
@@ -718,12 +590,13 @@ func TestDeriveLogsTable(t *testing.T) {
 	}
 }
 
-// --- resolveOtel integration tests ---
+// --- resolveOtel integration tests (state-only signature, post-#87) ---
 //
-// resolveOtel is the orchestration that ties flag parsing + saved state into
-// the final (otel, metricsTable, logsTable) tuple that drives config.toml
-// patching. These tests exercise the full matrix of flag combinations
-// against a populated state file, mirroring databricks-claude's behavior.
+// #87 turned resolveOtel into a pure read-only consumer of saved state.
+// The session-time flag combinations that drove the legacy resolveOtel
+// matrix moved to TestResolveConfigOTEL_OrchestrationMatrix
+// (cli_config_test.go) — that's the writer side. resolveOtel is the
+// reader side and is much smaller now.
 
 func TestResolveOtel(t *testing.T) {
 	const customMetrics = "cat.schema.codex_otel_metrics"
@@ -731,110 +604,59 @@ func TestResolveOtel(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		args        *Args
 		saved       persistentState
 		wantOtel    bool
 		wantMetrics string
 		wantLogs    string
 	}{
 		{
-			name:     "no flags, empty state: otel off, both tables empty",
-			args:     &Args{},
+			name:     "empty state: otel off, both tables empty",
 			saved:    persistentState{},
 			wantOtel: false, wantMetrics: "", wantLogs: "",
 		},
 		{
-			name:        "no flags but saved tables: implicit-enable, both tables flow through",
-			args:        &Args{},
+			name:        "saved tables, no disables: otel on, both tables flow through",
 			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
 			wantOtel:    true,
 			wantMetrics: customMetrics,
 			wantLogs:    customLogs,
 		},
 		{
-			name:        "--otel with empty state uses both defaults",
-			args:        &Args{Otel: true},
-			saved:       persistentState{},
-			wantOtel:    true,
-			wantMetrics: "main.codex_telemetry.codex_otel_metrics",
-			wantLogs:    "main.codex_telemetry.codex_otel_logs",
-		},
-		{
-			name:     "--no-otel with saved tables: hard off, both tables empty",
-			args:     &Args{NoOtel: true},
-			saved:    persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
+			name:     "saved tables but both Disabled bits set: hard off (the post-`config otel disable` shape)",
+			saved:    persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelMetricsDisabled: true, OtelLogsDisabled: true},
 			wantOtel: false, wantMetrics: "", wantLogs: "",
 		},
 		{
-			name:        "--no-otel-metrics with saved tables: metrics off, LOGS PRESERVED (the bug we fixed)",
-			args:        &Args{NoOtelMetrics: true},
-			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
-			wantOtel:    true, // implicit-enable from saved state
+			name:        "saved tables with metrics disabled only: logs preserved (the per-signal disable shape)",
+			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelMetricsDisabled: true},
+			wantOtel:    true,
 			wantMetrics: "",
 			wantLogs:    customLogs,
 		},
 		{
-			name:        "--no-otel-logs with saved tables: logs off, METRICS PRESERVED",
-			args:        &Args{NoOtelLogs: true},
-			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
-			wantOtel:    true, // implicit-enable from saved state
-			wantMetrics: customMetrics,
-			wantLogs:    "",
-		},
-		{
-			name:        "--otel --no-otel-metrics: explicit on + metrics-off, logs default applies",
-			args:        &Args{Otel: true, NoOtelMetrics: true},
-			saved:       persistentState{},
-			wantOtel:    true,
-			wantMetrics: "",
-			wantLogs:    "main.codex_telemetry.codex_otel_logs",
-		},
-		{
-			name:        "--otel --no-otel-logs: explicit on + logs-off, metrics default applies",
-			args:        &Args{Otel: true, NoOtelLogs: true},
-			saved:       persistentState{},
-			wantOtel:    true,
-			wantMetrics: "main.codex_telemetry.codex_otel_metrics",
-			wantLogs:    "",
-		},
-		{
-			name: "explicit --otel-metrics-table flag implicit-enables otel even without --otel",
-			args: &Args{
-				OtelMetricsTable:    customMetrics,
-				OtelMetricsTableSet: true,
-			},
-			saved:       persistentState{},
+			name:        "saved tables with logs disabled only: metrics preserved",
+			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelLogsDisabled: true},
 			wantOtel:    true,
 			wantMetrics: customMetrics,
-			wantLogs:    "cat.schema.codex_otel_logs", // derived
-		},
-		{
-			name:     "--no-otel beats everything else (even an explicit metrics flag)",
-			args:     &Args{NoOtel: true, OtelMetricsTable: customMetrics, OtelMetricsTableSet: true},
-			saved:    persistentState{},
-			wantOtel: false, wantMetrics: "", wantLogs: "",
-		},
-		{
-			name:        "--no-otel-metrics + --no-otel-logs with saved tables: both off, but otel stays implicit-on",
-			args:        &Args{NoOtelMetrics: true, NoOtelLogs: true},
-			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
-			wantOtel:    true,
-			wantMetrics: "",
 			wantLogs:    "",
 		},
 		{
-			name:        "saved metrics only: implicit-enable, logs derived from metrics",
-			args:        &Args{},
+			name:        "saved metrics only: otel on, logs empty",
 			saved:       persistentState{OtelMetricsTable: customMetrics},
 			wantOtel:    true,
 			wantMetrics: customMetrics,
-			wantLogs:    "cat.schema.codex_otel_logs",
+			wantLogs:    "",
+		},
+		{
+			name:     "Disabled bits set on empty tables: still off (no-op)",
+			saved:    persistentState{OtelMetricsDisabled: true, OtelLogsDisabled: true},
+			wantOtel: false, wantMetrics: "", wantLogs: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			otel, metrics, logs := resolveOtel(tc.args, tc.saved)
+			otel, metrics, logs := resolveOtel(tc.saved)
 			if otel != tc.wantOtel {
 				t.Errorf("otel: got %v, want %v", otel, tc.wantOtel)
 			}

--- a/serve_cmd.go
+++ b/serve_cmd.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// runServeCommand dispatches `databricks-codex serve [flags]`. args is
+// everything after the literal "serve" token (e.g. ["--idle-timeout", "5m"]).
+//
+// Mirrors hooksCommand's runHooksCommand shape but is a leaf — there are no
+// sub-subcommands. databricks-claude #174 has install/uninstall/status here
+// for daemon-mode OS service registration; codex has no daemon mode (no
+// LaunchAgent / systemd-user / schtasks equivalent yet) so those are
+// deferred.
+//
+// Flag parsing is driven by serveCommand.Parse so the tree is the single
+// source of truth for the flag set. The runner constructs an Args struct
+// with Headless=true and the parsed IdleTimeout, then calls runProxyMode —
+// the same launcher the legacy `databricks-codex --headless` path used. The
+// Args struct (declared in main.go) keeps Headless/IdleTimeout fields for
+// exactly this reason; parseArgs no longer populates them after #89.
+func runServeCommand(args []string) error {
+	parsed, err := serveCommand.Parse(args)
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	if parsed.Bools["help"] {
+		_ = cmd.Render(os.Stdout, serveCommand, nil)
+		return nil
+	}
+
+	a, err := buildServeArgs(parsed)
+	if err != nil {
+		return err
+	}
+
+	runServeProxy(a)
+	return nil
+}
+
+// runServeProxy is the proxy-launch hook that runServeCommand invokes after
+// flag parsing. Replaceable from tests so serve_cmd_test.go can spy on the
+// Args struct without actually starting the proxy.
+//
+// In production this points at runProxyMode (defined in main.go), which is
+// the same launcher the transparent-wrapper path uses. The branch inside
+// runProxyMode that wraps the handler with /shutdown + idle-timeout fires
+// when a.Headless is true — i.e. exactly what the serve dispatcher sets it
+// to.
+var runServeProxy = func(a *Args) {
+	runProxyMode(a)
+}
+
+// buildServeArgs maps a parsed cmd.ParseResult into the Args struct that
+// runProxyMode consumes. The mapping is exhaustive over the flags declared
+// on serveCommand in commands.go; a flag-set parity test
+// (serve_cmd_test.go) catches drift in either direction.
+//
+// --idle-timeout is the only flag with strict parsing: an invalid duration
+// is returned as a fail-loud error (matching the legacy --idle-timeout root
+// flag's behaviour, including rejection of bare ints like "30" and empty
+// values like "--idle-timeout=").
+func buildServeArgs(r *cmd.ParseResult) (*Args, error) {
+	a := &Args{
+		Headless:    true,            // serve always runs headless
+		IdleTimeout: 30 * time.Minute, // matches the pre-#89 default
+	}
+
+	if r.Set["idle-timeout"] {
+		raw := r.Strings["idle-timeout"]
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("serve: --idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
+		}
+		a.IdleTimeout = d
+	}
+
+	a.Profile = r.Strings["profile"]
+	a.Verbose = r.Bools["verbose"]
+	a.LogFile = r.Strings["log-file"]
+	a.Upstream = r.Strings["upstream"]
+	a.ProxyAPIKey = r.Strings["proxy-api-key"]
+	a.TLSCert = r.Strings["tls-cert"]
+	a.TLSKey = r.Strings["tls-key"]
+	a.NoUpdateCheck = r.Bools["no-update-check"]
+
+	if r.Set["model"] {
+		a.Model = r.Strings["model"]
+		a.ModelSet = true
+	}
+
+	if r.Set["port"] {
+		raw := r.Strings["port"]
+		if raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("serve: --port: %q is not an integer", raw)
+			}
+			a.PortFlag = n
+		}
+	}
+
+	return a, nil
+}

--- a/serve_cmd_test.go
+++ b/serve_cmd_test.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServeCommandTreeParity verifies bidirectional parity between the
+// serveCommand declaration (commands.go) and the buildServeArgs mapping
+// (serve_cmd.go). Mirrors hooks_cmd_test.go's TestHooksCommandTreeParity
+// shape, adapted for a leaf command (no sub-subcommands).
+//
+// Bidirectional contract:
+//   - tree → mapper: every flag on serveCommand must be consumed by
+//     buildServeArgs (or by runServeCommand's --help short-circuit).
+//   - mapper → tree: every flag buildServeArgs consumes must be declared
+//     on serveCommand. Drift fails the test loudly.
+//
+// The expected set is hard-coded so adding a flag to serveCommand without
+// wiring it into buildServeArgs trips this check on the next test run.
+func TestServeCommandTreeParity(t *testing.T) {
+	expected := map[string]bool{
+		"idle-timeout":    true,
+		"profile":         true,
+		"port":            true,
+		"model":           true,
+		"upstream":        true,
+		"log-file":        true,
+		"verbose":         true,
+		"proxy-api-key":   true,
+		"tls-cert":        true,
+		"tls-key":         true,
+		"no-update-check": true,
+		"help":            true,
+	}
+
+	got := make(map[string]bool, len(serveCommand.Flags))
+	for _, f := range serveCommand.AllFlags() {
+		got[f.Name] = true
+	}
+
+	for name := range expected {
+		if !got[name] {
+			t.Errorf("serveCommand should declare --%s but does not", name)
+		}
+	}
+	for name := range got {
+		if !expected[name] {
+			t.Errorf("serveCommand declares --%s but the parity contract does not list it (add to expected, or remove from tree)", name)
+		}
+	}
+}
+
+// TestRootSubcommandsIncludeServe is the structural counterpart to the
+// breaking change in #89: rootCommand must declare serve so dispatch from
+// main.go (and shell completion) finds it. Removing serveCommand from
+// rootCommand.Subcommands flips this assertion to fail.
+func TestRootSubcommandsIncludeServe(t *testing.T) {
+	if rootCommand.Subcommand("serve") == nil {
+		t.Fatal("rootCommand has no `serve` subcommand — tree wiring lost")
+	}
+}
+
+// TestRootCommandLegacyHeadlessFlagsRemoved locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear on
+// rootCommand any more. If a future refactor accidentally re-adds one,
+// this test fires and points at the migration sub-issue.
+func TestRootCommandLegacyHeadlessFlagsRemoved(t *testing.T) {
+	declared := make(map[string]bool)
+	for _, f := range rootCommand.AllFlags() {
+		declared[f.Name] = true
+	}
+	for _, flag := range []string{"headless", "idle-timeout"} {
+		if declared[flag] {
+			t.Errorf("rootCommand still declares --%s after #89 migration; the user-facing flag must move to `serve`", flag)
+		}
+	}
+}
+
+// --- buildServeArgs unit tests ---
+//
+// These exercise the parsed-flag → Args mapping directly. Together with
+// TestServeCommandTreeParity, they form the safety net for "drift between
+// what the tree advertises and what the runner actually wires through".
+
+func TestBuildServeArgs_DefaultIdleTimeout(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Headless {
+		t.Error("expected Headless=true (serve always runs headless)")
+	}
+	if a.IdleTimeout != 30*time.Minute {
+		t.Errorf("expected default IdleTimeout=30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutSeconds(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30s"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 30*time.Second {
+		t.Errorf("expected 30s, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutMinutes(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "5m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutHours(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "1h"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != time.Hour {
+		t.Errorf("expected 1h, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEquals(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout=2h30m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 2*time.Hour+30*time.Minute {
+		t.Errorf("expected 2h30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutZeroDisables(t *testing.T) {
+	// Per AC: --idle-timeout 0 disables idle shutdown. time.ParseDuration
+	// accepts "0" as a zero-value duration.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "0"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected 0 (disabled), got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutBareIntRejected(t *testing.T) {
+	// Matches the legacy --idle-timeout root-flag behaviour: bare ints
+	// like "30" (no unit) are rejected as ambiguous.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for bare-int --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutGarbageRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30mins"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for '30mins' --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEmptyRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout="})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for empty --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_Profile(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--profile", "aidev"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.Profile != "aidev" {
+		t.Errorf("expected Profile=%q, got %q", "aidev", a.Profile)
+	}
+}
+
+func TestBuildServeArgs_Port(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--port", "9999"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.PortFlag != 9999 {
+		t.Errorf("expected PortFlag=9999, got %d", a.PortFlag)
+	}
+}
+
+func TestBuildServeArgs_Verbose(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"-v"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Verbose {
+		t.Error("expected Verbose=true for -v")
+	}
+}
+
+func TestBuildServeArgs_TLSPair(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--tls-cert", "/tmp/c.pem", "--tls-key", "/tmp/k.pem"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.TLSCert != "/tmp/c.pem" || a.TLSKey != "/tmp/k.pem" {
+		t.Errorf("expected TLS cert/key wired, got cert=%q key=%q", a.TLSCert, a.TLSKey)
+	}
+}
+
+func TestBuildServeArgs_Model(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--model", "databricks-gpt-5-4-mini"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true when --model is passed")
+	}
+	if a.Model != "databricks-gpt-5-4-mini" {
+		t.Errorf("expected Model=%q, got %q", "databricks-gpt-5-4-mini", a.Model)
+	}
+}
+
+// TestBuildServeArgs_HeadlessAlwaysTrue is the AC-positive assertion: the
+// serve subcommand MUST set Headless=true on the Args it constructs. If
+// a future refactor accidentally drops this, runProxyMode would launch
+// codex as a child instead of running the proxy headlessly — the exact
+// silent-degradation hazard the issue's "byte-identical behavior" AC
+// guards against.
+func TestBuildServeArgs_HeadlessAlwaysTrue(t *testing.T) {
+	cases := [][]string{
+		{},                                     // bare serve
+		{"--idle-timeout", "5m"},               // typical IDE invocation
+		{"--profile", "aidev", "--port", "0"},  // edge values
+		{"--verbose"},                          // debug toggle
+	}
+	for _, args := range cases {
+		r, _ := serveCommand.Parse(args)
+		a, err := buildServeArgs(r)
+		if err != nil {
+			t.Errorf("buildServeArgs(%v) error: %v", args, err)
+			continue
+		}
+		if !a.Headless {
+			t.Errorf("buildServeArgs(%v): Headless should be true; serve always runs headless", args)
+		}
+	}
+}
+
+// --- runServeCommand integration tests (with spy) ---
+//
+// runServeCommand calls runServeProxy → runProxyMode. The latter does I/O
+// (proxy bind, auth check, codex lookup) we don't want in unit tests, so
+// these tests swap runServeProxy for a spy that captures the Args struct.
+// This is the "AC-positive" pattern called out in the issue's pitfalls
+// section: assert what the new code path actually does, not just "no
+// error raised".
+
+func TestRunServeCommand_HelpReturnsNilWithoutLaunching(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--help"}); err != nil {
+		t.Errorf("runServeCommand([--help]) returned error: %v", err)
+	}
+	if called {
+		t.Error("--help short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_HelpShortAliasReturnsNil(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"-h"}); err != nil {
+		t.Errorf("runServeCommand([-h]) returned error: %v", err)
+	}
+	if called {
+		t.Error("-h short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_InvalidIdleTimeoutReturnsError(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	err := runServeCommand([]string{"--idle-timeout", "not-a-duration"})
+	if err == nil {
+		t.Fatal("expected error for invalid --idle-timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "idle-timeout") {
+		t.Errorf("error %q should mention idle-timeout", err)
+	}
+	if called {
+		t.Error("invalid flag must NOT call runServeProxy")
+	}
+}
+
+// TestRunServeCommand_BareServeInvokesProxyWithDefaults exercises the
+// happy path: bare `databricks-codex serve` (no flags) must call
+// runProxyMode with Headless=true and the default 30m idle timeout. Catches
+// the regression where runServeCommand returns early without invoking the
+// launcher.
+func TestRunServeCommand_BareServeInvokesProxyWithDefaults(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{}); err != nil {
+		t.Fatalf("runServeCommand([]) returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 30*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 30m (default)", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesIdleTimeoutThrough is the headline AC test:
+// `databricks-codex serve --idle-timeout 5m` must reach runProxyMode with
+// IdleTimeout=5m. Asserts the FULL pipeline (parse → buildServeArgs →
+// runServeProxy) — a regression in any step fails this. This is the
+// positive assertion the issue's pitfalls section calls out: "serve
+// invokes runHeadless with idle-timeout=5m via a fake/spy, not 'no error
+// raised'".
+func TestRunServeCommand_PassesIdleTimeoutThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--idle-timeout", "5m"}); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 5*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 5m", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesAllFlagsThrough exercises the full mapping:
+// every serve flag (except --help) must reach the Args struct. Catches
+// the case where a flag is added to serveCommand and the parity test
+// passes (because buildServeArgs has a corresponding name lookup) but the
+// value silently drops on the floor.
+func TestRunServeCommand_PassesAllFlagsThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	args := []string{
+		"--idle-timeout", "10m",
+		"--profile", "aidev",
+		"--port", "55555",
+		"--model", "test-model",
+		"--upstream", "https://gw.example.com/openai/v1",
+		"--log-file", "/tmp/serve.log",
+		"--verbose",
+		"--proxy-api-key", "secret",
+		"--tls-cert", "/tmp/c.pem",
+		"--tls-key", "/tmp/k.pem",
+		"--no-update-check",
+	}
+	if err := runServeCommand(args); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+
+	checks := []struct {
+		name      string
+		got, want interface{}
+	}{
+		{"Headless", captured.Headless, true},
+		{"IdleTimeout", captured.IdleTimeout, 10 * time.Minute},
+		{"Profile", captured.Profile, "aidev"},
+		{"PortFlag", captured.PortFlag, 55555},
+		{"Model", captured.Model, "test-model"},
+		{"ModelSet", captured.ModelSet, true},
+		{"Upstream", captured.Upstream, "https://gw.example.com/openai/v1"},
+		{"LogFile", captured.LogFile, "/tmp/serve.log"},
+		{"Verbose", captured.Verbose, true},
+		{"ProxyAPIKey", captured.ProxyAPIKey, "secret"},
+		{"TLSCert", captured.TLSCert, "/tmp/c.pem"},
+		{"TLSKey", captured.TLSKey, "/tmp/k.pem"},
+		{"NoUpdateCheck", captured.NoUpdateCheck, true},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("Args.%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestHeadlessEnsureConfig_UsesServeSubcommand is the load-bearing test
+// for AC #5: "Hook entry must continue to bring the proxy up correctly —
+// the headlessEnsure-equivalent path now reuses the `serve` codepath
+// internally, not the removed --headless flag."
+//
+// pkg/headless.buildArgs uses Config.EnsureCommand as the prefix. With
+// EnsureCommand=["serve"], the spawned subprocess is `databricks-codex
+// serve --port=N [--tls-cert=... --tls-key=...]`. With EnsureCommand
+// empty, it would default back to `databricks-codex --headless ...` —
+// which would IMMEDIATELY fail since #89 deletes that flag. This test
+// fails loudly if a future refactor drops the EnsureCommand field.
+func TestHeadlessEnsureConfig_UsesServeSubcommand(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{})
+	if len(cfg.EnsureCommand) == 0 {
+		t.Fatal("headlessEnsureConfig must set EnsureCommand so the spawned subprocess invokes a real subcommand (not the removed --headless flag)")
+	}
+	if cfg.EnsureCommand[0] != "serve" {
+		t.Errorf("expected EnsureCommand[0]=%q, got %q (#89: hook spawn must invoke `serve`)", "serve", cfg.EnsureCommand[0])
+	}
+}
+
+// TestHeadlessEnsureConfig_TLSPropagated verifies the TLS knobs from
+// persistent state reach the headless.Config so the spawned subprocess
+// gets --tls-cert / --tls-key flags. Locks the existing semantics — the
+// #89 EnsureCommand change must NOT regress TLS plumbing.
+func TestHeadlessEnsureConfig_TLSPropagated(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{TLSCert: "/tmp/c.pem", TLSKey: "/tmp/k.pem"})
+	if cfg.TLSCert != "/tmp/c.pem" || cfg.TLSKey != "/tmp/k.pem" {
+		t.Errorf("TLS state must reach headless.Config; got cert=%q key=%q", cfg.TLSCert, cfg.TLSKey)
+	}
+	if cfg.Scheme != "https" {
+		t.Errorf("Scheme should be https when TLSCert is set, got %q", cfg.Scheme)
+	}
+}
+
+// TestServeHelpRendersAllFlags is a smoke check that the serveHelpTemplate
+// string mentions each of the flag names declared on serveCommand.
+// Prevents the help text from drifting silently when a flag is added or
+// renamed in commands.go.
+func TestServeHelpRendersAllFlags(t *testing.T) {
+	for _, name := range []string{
+		"--idle-timeout", "--profile", "--port", "--model",
+		"--upstream", "--log-file", "--verbose",
+		"--proxy-api-key", "--tls-cert", "--tls-key",
+		"--no-update-check", "--help",
+	} {
+		if !strings.Contains(serveHelpTemplate, name) {
+			t.Errorf("serveHelpTemplate missing %q", name)
+		}
+	}
+}

--- a/state.go
+++ b/state.go
@@ -9,14 +9,25 @@ import (
 
 // persistentState is the JSON schema for ~/.codex/.databricks-codex.json.
 // This file survives config.toml restore and persists across sessions.
+//
+// OtelMetricsDisabled / OtelLogsDisabled (added in #87) are the explicit
+// "user has run `config otel disable`" markers. They exist so the `config
+// otel disable` UX can preserve the table-name preferences for a future
+// re-enable while still suppressing OTEL export on the next session — the
+// two-store equivalent of databricks-claude's "settings.json absence means
+// off, state file holds preferences" model, adapted for codex where there
+// is no settings.json env block (config.toml is owned by the proxy
+// lifecycle and rewritten at every session start).
 type persistentState struct {
-	Profile          string `json:"profile,omitempty"`
-	OtelLogsTable    string `json:"otel_logs_table,omitempty"`
-	OtelMetricsTable string `json:"otel_metrics_table,omitempty"`
-	Model            string `json:"model,omitempty"`
-	Port             int    `json:"port,omitempty"`
-	TLSCert          string `json:"tls_cert,omitempty"`
-	TLSKey           string `json:"tls_key,omitempty"`
+	Profile             string `json:"profile,omitempty"`
+	OtelLogsTable       string `json:"otel_logs_table,omitempty"`
+	OtelMetricsTable    string `json:"otel_metrics_table,omitempty"`
+	OtelMetricsDisabled bool   `json:"otel_metrics_disabled,omitempty"`
+	OtelLogsDisabled    bool   `json:"otel_logs_disabled,omitempty"`
+	Model               string `json:"model,omitempty"`
+	Port                int    `json:"port,omitempty"`
+	TLSCert             string `json:"tls_cert,omitempty"`
+	TLSKey              string `json:"tls_key,omitempty"`
 }
 
 const defaultPort = 49154


### PR DESCRIPTION
Tracker PR for the CLI command-tree restructure milestone (umbrella #85). **Do not merge** until all sub-issues land.

## Sub-issues (dependency-ordered)

- [ ] #86 — Command-tree registry; migrate root (`feat:`)
- [ ] #87 — `config` subcommand: otel enable/disable + show (`feat!:`)
- [ ] #88 — `hooks` subcommand (`feat!:`)
- [ ] #89 — `serve` subcommand: absorb `--headless` / `--idle-timeout` (`feat!:`)

Ordering: #86 → (#87 ∥ #88) → #89. #87 and #88 are independent and can review in parallel.

## Workflow

- Sub-PRs target this branch (`feat/cli-command-tree`), **not master**.
- Sub-branches: `issue/<N>-<slug>` cut off this integration branch (carry prior sub-PRs' work).
- CI runs on this integration branch after each sub-PR merge — `.github/workflows/*.yml` `push:` and `pull_request:` triggers must glob `[master, 'feat/**']` (landed by #86).
- Whole integration branch merges to `master` once all sub-issues are done — one large reviewed change, not N partial ones.

## Architecture invariants (full detail in #85)

- Transparent-proxy default path stays flag-driven and bare.
- Hooks deployment mode stays a first-class option (commands rename; behavior preserved).
- Source of truth becomes a command tree, declared once, that generates parsing + help + completion.

Mirrors databricks-claude integration branch (#170 → #171 → #172/#173 → #174).
