### PR TITLE
feat!: serve subcommand (consolidate --headless / --idle-timeout) (#89)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,12 @@ Transparent wrapper for the OpenAI Codex CLI that auto-injects Databricks OAuth 
 
 | File | Description |
 |------|-------------|
-| `main.go` | CLI entry point: flag parsing, resolution chains for profile/model/otel-logs-table, proxy startup, config.toml patching, and Codex child process lifecycle |
+| `main.go` | CLI entry point: flag parsing, resolution chains for profile/model/otel-logs-table, `runProxyMode` launcher, config.toml patching, and Codex child process lifecycle. `runProxyMode` is shared by the transparent-wrapper path and the `serve` subcommand path. |
+| `serve_cmd.go` | `runServeCommand` dispatcher for the `serve` subcommand (#89). Replaces the legacy `--headless` / `--idle-timeout` root flags. Constructs an `Args` struct with `Headless=true` and the parsed idle timeout, then calls `runProxyMode`. |
+| `cli_config.go` | `runConfigCommand` dispatcher for the `config` subcommand (#87). Persistent-config editor for OTEL signals + diagnostic `config show`. |
+| `hooks.go` | `headlessEnsure` / `installHooks` / `uninstallHooks`. The hook spawn path now invokes `databricks-codex serve --port=N` (#89) — set via `headless.Config.EnsureCommand`. |
+| `hooks_cmd.go` | `runHooksCommand` dispatcher for the `hooks` subcommand (#88). install / uninstall / session-start. |
+| `commands.go` | Source-of-truth `cmd.Command` declarations: `rootCommand`, `configCommand`, `hooksCommand`, `serveCommand`. Drives `parseArgs`, completion scripts, and help rendering. |
 | `token.go` | `databricksFetcher` implements `tokencache.TokenFetcher` via `databricks auth token`. Also `DiscoverHost` (via `databricks auth env`) and `ConstructGatewayURL` (SCIM `/Me` for workspace ID) |
 | `config.go` | `ConfigManager` coordinates tomlconfig, filelock, and session registry. `Setup()` backs up + patches; `Restore()` handles multi-session handoff or full restore |
 | `state.go` | `persistentState` JSON at `~/.codex/.databricks-codex.json` — persists profile, model, and otel-logs-table across sessions |

--- a/README.md
+++ b/README.md
@@ -93,11 +93,10 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 | `--proxy-api-key` | disabled | Require this API key on all local proxy requests |
 | `--tls-cert` | | TLS certificate file for the local proxy (requires `--tls-key`) |
 | `--tls-key` | | TLS private key file for the local proxy (requires `--tls-cert`) |
-| `--headless` | `false` | Start proxy without launching codex (for IDE extensions or hooks) |
-| `--idle-timeout` | `30m` | Idle timeout for headless mode (`0` disables; bare number = minutes) |
 | `--version` | | Print version and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `codex --help` output, then exit |
 
+Headless / idle-timeout knobs live under `databricks-codex serve` (see [`serve` Subcommand](#serve-subcommand)).
 Hook installation lives under `databricks-codex hooks` (see [`hooks` Subcommand](#hooks-subcommand)).
 
 All other flags and args are forwarded to `codex`.
@@ -107,6 +106,13 @@ All other flags and args are forwarded to `codex`.
 > `--otel-logs-table`, and `--print-env` are gone. They moved under
 > `databricks-codex config` — see the [config Subcommand](#config-subcommand)
 > section below.
+
+> **Breaking in v0.13.0:** the session-mode root flags `--headless` and
+> `--idle-timeout` are gone. They moved under `databricks-codex serve` —
+> see the [serve Subcommand](#serve-subcommand) section below. The
+> SessionStart hook installed by `databricks-codex hooks install`
+> continues to work transparently — it spawns `databricks-codex serve`
+> internally now.
 
 ## config Subcommand
 
@@ -191,9 +197,47 @@ This lets the wrapper:
 
 `databricks-codex --help` (or `-h`) prints the wrapper's own flags followed by the complete `codex --help` output.
 
+## serve Subcommand
+
+`databricks-codex serve` runs the proxy in headless mode without launching `codex`. Useful when an IDE extension or other tool needs the proxy up but doesn't want a child `codex` process. Replaces the legacy root flags `--headless` and `--idle-timeout`, which were removed in v0.13.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--idle-timeout` | `30m` | Shut the proxy down after this much idle time. `0` disables (long-running IDE sessions). Accepts Go duration strings: `30s`, `5m`, `1h`, `2h30m`. Bare integers (e.g. `30`) are rejected. |
+| `--profile` | state file > `DEFAULT` | Databricks CLI profile. |
+| `--port` | state file > `49154` | Proxy listen port. |
+| `--model` | saved | Model name (saved to state file when supplied). |
+| `--upstream` | auto-discovered | Override the AI Gateway URL. |
+| `--log-file` | | Write debug logs to this file (combinable with `--verbose`). |
+| `--verbose`, `-v` | `false` | Enable debug logging to stderr. |
+| `--proxy-api-key` | disabled | Require this API key on all proxy requests. |
+| `--tls-cert` | | TLS certificate file (requires `--tls-key`). |
+| `--tls-key` | | TLS private key file (requires `--tls-cert`). |
+| `--no-update-check` | | Skip the automatic update check on startup. |
+| `--help`, `-h` | | Show help and exit. |
+
+The proxy prints `PROXY_URL=http://127.0.0.1:<port>` (or `https://...` with TLS) to stdout once bound. It exits when:
+
+- `SIGINT` or `SIGTERM` is received.
+- `POST /shutdown` is hit on the proxy URL.
+- `--idle-timeout` elapses with zero in-flight requests.
+
+```bash
+# Default 30-minute idle timeout:
+databricks-codex serve
+
+# Tight timeout for tests / CI:
+databricks-codex serve --idle-timeout 5m
+
+# Disable idle shutdown for a long-running IDE session:
+databricks-codex serve --idle-timeout 0
+```
+
+The SessionStart hook installed by `databricks-codex hooks install` spawns `databricks-codex serve` under the hood — you don't need to invoke this manually for the hooks path.
+
 ## `hooks` Subcommand
 
-Install hooks so every Codex session auto-starts the proxy on startup — no manual `--headless` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
+Install hooks so every Codex session auto-starts the proxy on startup — no manual `databricks-codex serve` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
 
 > **First-time setup:** Run `databricks-codex` at least once before installing hooks. This writes `~/.codex/config.toml` so the proxy is used for all Codex sessions.
 
@@ -215,7 +259,7 @@ This merges a **SessionStart** hook into `~/.codex/hooks.json` and enables the `
 
 ### Shutdown
 
-Unlike Claude Code, the Codex CLI does not have a `SessionEnd` hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `--idle-timeout`). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
+Unlike Claude Code, the Codex CLI does not have a `SessionEnd` hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `databricks-codex serve --idle-timeout <dur>` for direct invocations; the SessionStart hook spawns the proxy with the default 30-minute timeout). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
 
 ### Uninstall
 

--- a/commands.go
+++ b/commands.go
@@ -25,9 +25,10 @@ import (
 // editor (the legacy --otel*/--print-env root flags) onto a discoverable
 // `config` subcommand; #88 lifts the hooks lifecycle flags
 // (--install-hooks / --uninstall-hooks / --headless-ensure) onto a `hooks`
-// subcommand. Both sets of legacy root-flag spellings are GONE in this
-// revision. serve is still tracked under #89. --profile and --port live on
-// Persistent so subcommand inheritance works for the migrated children.
+// subcommand. #89 lifts the remaining session-mode root flags (--headless,
+// --idle-timeout) onto a `serve` subcommand. All three sets of legacy
+// root-flag spellings are GONE in this revision. --profile and --port live
+// on Persistent so subcommand inheritance works for the migrated children.
 var rootCommand = cmd.Command{
 	Name:  "databricks-codex",
 	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
@@ -60,9 +61,10 @@ var rootCommand = cmd.Command{
 
 	// Order matches the legacy flagDefs slice so the bash/zsh/fish
 	// completion output stays byte-identical with the pre-tree binary
-	// for the flags that survived #87/#88. The migrated OTEL/--print-env
-	// and hooks-lifecycle flags are gone from BOTH this slice and
-	// completion_flags.go's `order` — that is the breaking surface change.
+	// for the flags that survived #87/#88/#89. The migrated OTEL/--print-env,
+	// hooks-lifecycle, and session-mode flags are gone from BOTH this slice
+	// and completion_flags.go's `order` — that is the breaking surface
+	// change.
 	Flags: []cmd.FlagDef{
 		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
 		{Name: "version", Description: "Print version and exit"},
@@ -73,21 +75,20 @@ var rootCommand = cmd.Command{
 		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
 		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
-		{Name: "headless", Description: "Start proxy without launching codex (for IDE extensions or hooks)"},
-		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true, Default: "30m"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
 	// Subcommands declared on the root. completion and update dispatch
 	// from main.go directly. config (added in #87) carries its own
 	// dispatcher in cli_config.go. hooks (added in #88) carries its own
-	// dispatcher in cli_hooks.go. serve remains as root flags for now —
-	// see #89.
+	// dispatcher in hooks_cmd.go. serve (added in #89) carries its own
+	// dispatcher in serve_cmd.go.
 	Subcommands: []cmd.Command{
 		completionCommand,
 		updateCommand,
 		configCommand,
 		hooksCommand,
+		serveCommand,
 	},
 }
 
@@ -230,6 +231,46 @@ var hooksCommand = cmd.Command{
 				{Name: "help", Short: "h", Description: "Show help message"},
 			},
 		},
+	},
+}
+
+// serveCommand declares the `serve` subcommand introduced in #89.
+// Consolidates the legacy `--headless` and `--idle-timeout` root flags into
+// a discoverable subcommand. Mirrors databricks-claude #174's `serve
+// --session-mode` entrypoint with a deliberately smaller scope: codex has
+// no daemon mode (no LaunchAgent/Service equivalent), so install/uninstall/
+// status sub-subcommands are deferred.
+//
+// Tree shape:
+//
+//	serve   [--idle-timeout D] [--profile P] [--port N] [--model M]
+//	        [--upstream U] [--log-file F] [--verbose|-v]
+//	        [--proxy-api-key K] [--tls-cert C] [--tls-key K]
+//	        [--no-update-check]
+//
+// Behavior is byte-identical with the deleted `databricks-codex --headless`
+// path: the runner constructs the same Args struct that parseArgs used to,
+// sets Headless=true, and dispatches into the shared runProxyMode launcher.
+// The hook-spawn path (headlessEnsure → headless.Ensure) is updated to
+// invoke `databricks-codex serve --port=N` instead of the removed
+// `--headless --port=N` so the SessionStart hook keeps working.
+var serveCommand = cmd.Command{
+	Name:  "serve",
+	Short: "Run the proxy in headless mode (consolidates --headless / --idle-timeout)",
+	Long:  serveHelpTemplate,
+	Flags: []cmd.FlagDef{
+		{Name: "idle-timeout", Description: "Idle timeout (default: 30m; 0 disables; e.g. 30s, 5m, 1h)", TakesArg: true, Default: "30m"},
+		{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+		{Name: "port", Description: "Proxy listen port (default: saved state > 49154)", TakesArg: true, StateKey: "port", Default: "49154"},
+		{Name: "model", Description: "Model to use (saved for future sessions)", TakesArg: true, StateKey: "model"},
+		{Name: "upstream", Description: "Override the AI Gateway URL (default: auto-discovered)", TakesArg: true},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+		{Name: "help", Short: "h", Description: "Show help message"},
 	},
 }
 
@@ -431,7 +472,56 @@ MUST remain fast and fail-fast: no interactive auth flow. If the user
 hasn't run 'databricks auth login' yet, this command exits 0 silently
 so the codex session is not blocked on a hook timeout.
 
+Internally spawns 'databricks-codex serve --port=N' (the #89 replacement
+for the deleted '--headless' root flag).
+
 Flags:
   --port int    Override saved port (default: saved state > 49154)
   --help, -h    Show this help message
+`
+
+const serveHelpTemplate = `Usage: databricks-codex serve [flags]
+
+Run the proxy in headless mode without launching codex. Replaces the
+legacy '--headless' and '--idle-timeout' root flags (#89) with a
+discoverable subcommand. Behavior is byte-identical with the removed
+flags — the hooks SessionStart entry and IDE extensions can call this
+directly to bring the proxy up and read PROXY_URL=... from stdout.
+
+Use this when:
+  - An IDE extension needs the proxy running but doesn't want a child
+    codex process. Read PROXY_URL=... from stdout, point your client
+    at it, then SIGTERM (or POST /shutdown) when done.
+  - Bringing up the proxy from a SessionStart hook. 'hooks install'
+    wires this for you under the hood.
+
+The proxy exits when:
+  - SIGINT or SIGTERM is received.
+  - POST /shutdown is hit on the proxy URL.
+  - --idle-timeout elapses with zero in-flight requests (default 30m;
+    0 disables idle shutdown).
+
+Flags:
+  --idle-timeout duration  Idle timeout (default 30m, 0 disables; e.g. 30s, 5m, 1h)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy listen port (default: state > 49154)
+  --model string           Model name (saved for future sessions)
+  --upstream string        Override the AI Gateway URL (default: auto-discovered)
+  --log-file string        Write debug logs to file (combinable with --verbose)
+  --verbose, -v            Enable debug logging to stderr
+  --proxy-api-key string   Require this API key on all proxy requests
+  --tls-cert string        TLS certificate file (requires --tls-key)
+  --tls-key string         TLS private key file (requires --tls-cert)
+  --no-update-check        Skip the automatic update check on startup
+  --help, -h               Show this help message
+
+Examples:
+  # Start the proxy with the default 30-minute idle timeout:
+  databricks-codex serve
+
+  # Start with a 5-minute idle timeout (test/CI scenarios):
+  databricks-codex serve --idle-timeout 5m
+
+  # Start with idle shutdown disabled (long-running IDE sessions):
+  databricks-codex serve --idle-timeout 0
 `

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -6,10 +6,13 @@ import "github.com/IceRhymers/databricks-claude/pkg/completion"
 // shell-script generation. Order is curated here (not implied by the tree)
 // because bash/zsh/fish completion output is order-sensitive — preserving
 // byte-equivalence with the pre-tree binary requires the original ordering
-// (--profile first, --port between --tls-key and --headless, etc.). Each
-// entry is derived from rootCommand so the tree remains the single source
-// of truth for which flags exist and what their descriptions / completers /
-// arg semantics are.
+// (--profile first, --port toward the end). Each entry is derived from
+// rootCommand so the tree remains the single source of truth for which
+// flags exist and what their descriptions / completers / arg semantics are.
+// #89 removed --headless and --idle-timeout from this slice (alongside the
+// rootCommand.Flags removal); they live on serveCommand now and are
+// reachable via the recursive subcommand-tree wiring in
+// rootCommand.CompletionSubcommands().
 //
 // Adding a new root flag requires:
 //  1. Append a FlagDef to rootCommand.Flags (or .Persistent) in commands.go.
@@ -34,8 +37,6 @@ var flagDefs = func() []completion.FlagDef {
 		"tls-cert",
 		"tls-key",
 		"port",
-		"headless",
-		"idle-timeout",
 		"no-update-check",
 	}
 	byName := map[string]completion.FlagDef{}
@@ -61,10 +62,12 @@ var knownFlags = rootCommand.KnownFlags()
 
 // knownSubcommands is the recursive shell-completion subcommand tree fed
 // to pkg/completion so `databricks-codex <TAB>` offers completion / update
-// / config / hooks, and `databricks-codex hooks <TAB>` offers install /
-// uninstall / session-start, `databricks-codex config <TAB>` offers otel
-// / show, etc. #87 introduced this wire-up alongside the dep bump to
-// databricks-claude v1.0.2 (which exports SubcommandDef); #88 adds the
-// hooks branch. See the doc-comment in internal/cmd/cmd.go for the prior
-// #86 omission.
+// / config / hooks / serve, and `databricks-codex hooks <TAB>` offers
+// install / uninstall / session-start, `databricks-codex config <TAB>`
+// offers otel / show, etc. #87 introduced this wire-up alongside the dep
+// bump to databricks-claude v1.0.2 (which exports SubcommandDef); #88
+// adds the hooks branch; #89 adds the serve leaf — picked up
+// automatically by the recursive walk now that serveCommand sits on
+// rootCommand.Subcommands. See the doc-comment in internal/cmd/cmd.go
+// for the prior #86 omission.
 var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/hooks.go
+++ b/hooks.go
@@ -26,13 +26,29 @@ var hooksKeyRegexp = regexp.MustCompile(`(?m)^\s*hooks\s*=`)
 //
 // The proxy shuts itself down via idle timeout — there is no corresponding
 // release hook because Codex CLI has no session-end event.
+//
+// #89: the spawned subprocess invokes the new `serve` subcommand instead of
+// the deleted `--headless` root flag. headless.Config.EnsureCommand replaces
+// the default `[]string{"--headless"}` prefix with `[]string{"serve"}`, so
+// pkg/headless.buildArgs now emits `databricks-codex serve --port=N
+// [--tls-cert=... --tls-key=...]`. Without this wiring, every SessionStart
+// hook firing would spawn a process that immediately fails arg parsing.
 func headlessEnsure(port int) error {
 	s := loadState()
+	return headless.Ensure(headlessEnsureConfig(port, s))
+}
+
+// headlessEnsureConfig assembles the headless.Config that headlessEnsure
+// passes to headless.Ensure. Extracted so a unit test can verify the
+// load-bearing fields (EnsureCommand routing through `serve`, the
+// $DATABRICKS_CODEX_MANAGED guard, the codex refcount path) without
+// spawning a real subprocess. Pure projection over (port, state).
+func headlessEnsureConfig(port int, s persistentState) headless.Config {
 	scheme := "http"
 	if s.TLSCert != "" {
 		scheme = "https"
 	}
-	return headless.Ensure(headless.Config{
+	return headless.Config{
 		Port:          port,
 		Scheme:        scheme,
 		TLSCert:       s.TLSCert,
@@ -40,7 +56,10 @@ func headlessEnsure(port int) error {
 		ManagedEnvVar: "DATABRICKS_CODEX_MANAGED",
 		LogPrefix:     "databricks-codex",
 		RefcountPath:  refcount.PathForPort(".databricks-codex-sessions", port),
-	})
+		// #89: spawn `databricks-codex serve --port=N` instead of the
+		// removed `databricks-codex --headless --port=N`.
+		EnsureCommand: []string{"serve"},
+	}
 }
 
 // installHooks merges the databricks-codex SessionStart and Stop hooks into

--- a/main.go
+++ b/main.go
@@ -60,6 +60,20 @@ func main() {
 		return
 	}
 
+	// `serve` subcommand — runs the proxy in headless mode. Consolidates the
+	// legacy --headless and --idle-timeout root flags removed in #89.
+	// Dispatched before parseArgs so the serve flag set is parsed by the
+	// serve subtree (not by the root parser, which no longer recognises
+	// --idle-timeout). The runner ends up calling runProxyMode with
+	// Headless=true — same launcher the legacy --headless path used.
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if err := runServeCommand(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
 		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
@@ -103,6 +117,28 @@ func main() {
 		os.Exit(0)
 	}
 
+	runProxyMode(a)
+}
+
+// runProxyMode is the shared launcher for both the transparent-wrapper path
+// (databricks-codex with no subcommand → spawn codex as a child) and the
+// headless path (databricks-codex serve → keep the proxy alive without a
+// child). The two paths converge on the same Args struct: the serve
+// dispatcher (runServeCommand) constructs Args with Headless=true and the
+// resolved IdleTimeout, while the wrapper path leaves both at their zero
+// values.
+//
+// The Headless/IdleTimeout fields are no longer set by parseArgs (the legacy
+// --headless / --idle-timeout root flags were removed in #89); they are
+// populated only by the serve dispatcher. Treating them as Args fields keeps
+// runProxyMode's signature stable and makes the serve test surface a simple
+// "spy on the Args struct that runServeCommand constructs" check (see
+// serve_cmd_test.go).
+//
+// Exits the process directly in the codex-launch path (with codex's exit
+// code); returns normally in the headless path so the serve dispatcher's
+// caller can os.Exit(0).
+func runProxyMode(a *Args) {
 	// Default: discard all logs (silent wrapper).
 	log.SetOutput(io.Discard)
 
@@ -417,6 +453,14 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath st
 // The OTEL state still drives the regular session: resolveOtel reads the
 // state file directly to decide whether to emit OTEL endpoints into the
 // proxy + config.toml.
+//
+// #89 removed the legacy --headless and --idle-timeout root flags. Their
+// effect now lives behind the `serve` subcommand. The Headless and
+// IdleTimeout fields stay on this struct because they are inputs to
+// runProxyMode — set by runServeCommand (serve_cmd.go) when the user
+// invokes `databricks-codex serve`. parseArgs never sets them; the
+// transparent-wrapper path leaves both at zero (Headless=false,
+// IdleTimeout=0) and runProxyMode skips the headless branches.
 type Args struct {
 	Verbose       bool
 	Version       bool
@@ -430,17 +474,21 @@ type Args struct {
 	Model         string
 	ModelSet      bool
 	PortFlag      int
-	Headless      bool
-	IdleTimeout   time.Duration
+	Headless      bool          // set by runServeCommand only (#89)
+	IdleTimeout   time.Duration // set by runServeCommand only (#89)
 	NoUpdateCheck bool
 	CodexArgs     []string
 }
 
-// parseArgs separates databricks-codex flags from codex flags.
+// parseArgs separates databricks-codex flags from codex flags. Recognises
+// only the root-flag set declared on rootCommand (commands.go); the legacy
+// --headless and --idle-timeout flags removed in #89 are intentionally NOT
+// recognised here — they will fall through to CodexArgs and be forwarded to
+// the wrapped codex binary, where they were never valid (codex will reject
+// them with its own error). Users should migrate to `databricks-codex serve
+// [--idle-timeout D]`.
 func parseArgs(args []string) (*Args, error) {
-	a := &Args{
-		IdleTimeout: 30 * time.Minute, // default
-	}
+	a := &Args{}
 
 	// knownFlags is defined at package level in completion_flags.go,
 	// derived from flagDefs so completions and parsing stay in sync.
@@ -540,19 +588,6 @@ func parseArgs(args []string) (*Args, error) {
 						i++
 						a.PortFlag, _ = strconv.Atoi(args[i])
 					}
-				case "--headless":
-					a.Headless = true
-				case "--idle-timeout":
-					raw := value
-					if raw == "" && i+1 < len(args) {
-						i++
-						raw = args[i]
-					}
-					d, err := time.ParseDuration(raw)
-					if err != nil {
-						return nil, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
-					}
-					a.IdleTimeout = d
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:
@@ -597,9 +632,7 @@ Databricks-Codex Flags:
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Fixed proxy port (default: 49154, saved to state)
-  --headless                Start proxy without launching codex (for IDE extensions)
-  --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables)
-  --no-update-check            Skip the automatic update check on startup
+  --no-update-check         Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
 
@@ -608,6 +641,7 @@ Subcommands:
   completion <shell>           Generate shell completions (bash, zsh, fish)
   update                       Check for a newer release and print upgrade instructions
   hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
+  serve [flags]                Run the proxy in headless mode (consolidates the deleted root flags)
 
 ────────────────────────────────────────────────────────────────────────────────
 Codex CLI Options:

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // mustParseArgs is a test helper that calls parseArgs and fails the test on error.
@@ -132,8 +131,15 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 	if len(a.CodexArgs) != 0 {
 		t.Errorf("expected no CodexArgs, got %v", a.CodexArgs)
 	}
-	if a.IdleTimeout != 30*time.Minute {
-		t.Errorf("expected default IdleTimeout=30m, got %v", a.IdleTimeout)
+	// #89 removed the --idle-timeout root flag; parseArgs no longer
+	// initialises Args.IdleTimeout. The default 30m default is now
+	// applied by buildServeArgs (serve_cmd.go); see
+	// TestBuildServeArgs_DefaultIdleTimeout.
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected zero IdleTimeout from parseArgs (no longer parsed), got %v", a.IdleTimeout)
+	}
+	if a.Headless {
+		t.Error("expected Headless=false from parseArgs (no longer parsed; set only by runServeCommand)")
 	}
 }
 
@@ -213,52 +219,14 @@ func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
 }
 
 // --- --idle-timeout strict parsing tests ---
-
-func TestParseArgs_IdleTimeout_Seconds(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "30s"})
-	if a.IdleTimeout != 30*time.Second {
-		t.Errorf("expected 30s, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Minutes(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "5m"})
-	if a.IdleTimeout != 5*time.Minute {
-		t.Errorf("expected 5m, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Hours(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout", "1h"})
-	if a.IdleTimeout != time.Hour {
-		t.Errorf("expected 1h, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_Equals(t *testing.T) {
-	a := mustParseArgs(t, []string{"--idle-timeout=2h30m"})
-	if a.IdleTimeout != 2*time.Hour+30*time.Minute {
-		t.Errorf("expected 2h30m, got %v", a.IdleTimeout)
-	}
-}
-
-func TestParseArgs_IdleTimeout_BareIntRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout", "30"}); err == nil {
-		t.Error("expected error for bare int --idle-timeout, got nil")
-	}
-}
-
-func TestParseArgs_IdleTimeout_GarbageRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout", "30mins"}); err == nil {
-		t.Error("expected error for '30mins' --idle-timeout, got nil")
-	}
-}
-
-func TestParseArgs_IdleTimeout_EmptyRejected(t *testing.T) {
-	if _, err := parseArgs([]string{"--idle-timeout="}); err == nil {
-		t.Error("expected error for empty --idle-timeout, got nil")
-	}
-}
+//
+// #89 removed --idle-timeout from the root flag set; parseArgs no longer
+// recognises it. The duration-parsing strict-validation surface (seconds /
+// minutes / hours / equals / bare-int rejected / garbage rejected / empty
+// rejected) lives on the serve subcommand now and is exercised by
+// TestBuildServeArgs_IdleTimeout* in serve_cmd_test.go. The legacy
+// --idle-timeout root flag falls through to CodexArgs (verified by
+// TestParseArgs_Table's "legacy --idle-timeout passes through" case).
 
 // Table-driven comprehensive test for parseArgs.
 func TestParseArgs_Table(t *testing.T) {
@@ -280,7 +248,6 @@ func TestParseArgs_Table(t *testing.T) {
 		{name: "--profile=value", args: []string{"--profile=aidev"}, want: Args{Profile: "aidev"}},
 		{name: "--model", args: []string{"--model", "my-model"}, want: Args{Model: "my-model", ModelSet: true}},
 		{name: "--port", args: []string{"--port", "9999"}, want: Args{PortFlag: 9999}},
-		{name: "--headless", args: []string{"--headless"}, want: Args{Headless: true}},
 		{name: "--no-update-check", args: []string{"--no-update-check"}, want: Args{NoUpdateCheck: true}},
 		{
 			// #88 removed --install-hooks; the legacy flag is no longer in
@@ -298,6 +265,22 @@ func TestParseArgs_Table(t *testing.T) {
 			name: "legacy --headless-ensure now passes through to codex",
 			args: []string{"--headless-ensure"},
 			want: Args{CodexArgs: []string{"--headless-ensure"}},
+		},
+		{
+			// #89 removed --headless; the legacy flag is no longer in
+			// knownFlags, so parseArgs forwards it to codex unchanged.
+			// Users should migrate to `databricks-codex serve`.
+			name: "legacy --headless now passes through to codex",
+			args: []string{"--headless"},
+			want: Args{CodexArgs: []string{"--headless"}},
+		},
+		{
+			// #89 removed --idle-timeout. parseArgs forwards both the
+			// flag name and its value as separate codex args (it has no
+			// way to know the flag took a value).
+			name: "legacy --idle-timeout now passes through to codex",
+			args: []string{"--idle-timeout", "5m"},
+			want: Args{CodexArgs: []string{"--idle-timeout", "5m"}},
 		},
 	}
 
@@ -512,10 +495,32 @@ func TestParseArgs_ProfileEquals(t *testing.T) {
 	}
 }
 
-func TestParseArgs_Headless(t *testing.T) {
+// TestParseArgs_LegacyHeadlessPassthrough locks the breaking surface from
+// #89: the deleted --headless root flag must NOT be recognised by parseArgs;
+// it forwards to CodexArgs unchanged. Catches the regression where someone
+// re-adds the case in parseArgs without bringing back the flag.
+func TestParseArgs_LegacyHeadlessPassthrough(t *testing.T) {
 	a := mustParseArgs(t, []string{"--headless"})
-	if !a.Headless {
-		t.Error("expected Headless=true for --headless")
+	if a.Headless {
+		t.Error("Args.Headless must NOT be set by parseArgs after #89; only runServeCommand sets it")
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--headless" {
+		t.Errorf("legacy --headless must pass through to CodexArgs, got %v", a.CodexArgs)
+	}
+}
+
+// TestParseArgs_LegacyIdleTimeoutPassthrough is the symmetric check for
+// the deleted --idle-timeout root flag.
+func TestParseArgs_LegacyIdleTimeoutPassthrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--idle-timeout", "5m"})
+	if a.IdleTimeout != 0 {
+		t.Errorf("Args.IdleTimeout must NOT be set by parseArgs after #89, got %v", a.IdleTimeout)
+	}
+	// The flag name and its value both fall through as positional args
+	// because parseArgs has no metadata to tell it the legacy flag took a
+	// value. Both tokens land in CodexArgs.
+	if len(a.CodexArgs) != 2 || a.CodexArgs[0] != "--idle-timeout" || a.CodexArgs[1] != "5m" {
+		t.Errorf("legacy --idle-timeout must pass through to CodexArgs, got %v", a.CodexArgs)
 	}
 }
 
@@ -533,11 +538,26 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	// Legacy hook flags (--install-hooks / --uninstall-hooks /
 	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
 	// OTEL/--print-env flags moved to `config otel`/`config show` in #87.
-	// The help text now lists `config` and `hooks` instead.
-	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--headless", "--idle-timeout", "--no-update-check", "--version", "--help", "config", "hooks"}
+	// --headless / --idle-timeout were lifted to the `serve` subcommand in
+	// #89. The help text now lists `config`, `hooks`, and `serve` instead.
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--no-update-check", "--version", "--help", "config", "hooks", "serve"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestHandleHelp_LegacyHeadlessFlagsAbsent locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear in the
+// root help text. If a future refactor re-adds them, this test fires.
+func TestHandleHelp_LegacyHeadlessFlagsAbsent(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, flag := range []string{"--headless", "--idle-timeout"} {
+		if strings.Contains(out, flag) {
+			t.Errorf("root help still mentions %q after #89 migration; users will discover the dead flag", flag)
 		}
 	}
 }
@@ -834,14 +854,7 @@ func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
 	for _, f := range rootCommand.AllFlags() {
 		var args []string
 		if f.TakesArg {
-			value := "value"
-			// --idle-timeout is the only flag with strict parsing; supply
-			// a valid duration so the test exercises the case arm itself
-			// rather than the duration-parse error path.
-			if f.Name == "idle-timeout" {
-				value = "30s"
-			}
-			args = []string{"--" + f.Name, value}
+			args = []string{"--" + f.Name, "value"}
 		} else {
 			args = []string{"--" + f.Name}
 		}

--- a/serve_cmd.go
+++ b/serve_cmd.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/IceRhymers/databricks-codex/internal/cmd"
+)
+
+// runServeCommand dispatches `databricks-codex serve [flags]`. args is
+// everything after the literal "serve" token (e.g. ["--idle-timeout", "5m"]).
+//
+// Mirrors hooksCommand's runHooksCommand shape but is a leaf — there are no
+// sub-subcommands. databricks-claude #174 has install/uninstall/status here
+// for daemon-mode OS service registration; codex has no daemon mode (no
+// LaunchAgent / systemd-user / schtasks equivalent yet) so those are
+// deferred.
+//
+// Flag parsing is driven by serveCommand.Parse so the tree is the single
+// source of truth for the flag set. The runner constructs an Args struct
+// with Headless=true and the parsed IdleTimeout, then calls runProxyMode —
+// the same launcher the legacy `databricks-codex --headless` path used. The
+// Args struct (declared in main.go) keeps Headless/IdleTimeout fields for
+// exactly this reason; parseArgs no longer populates them after #89.
+func runServeCommand(args []string) error {
+	parsed, err := serveCommand.Parse(args)
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	if parsed.Bools["help"] {
+		_ = cmd.Render(os.Stdout, serveCommand, nil)
+		return nil
+	}
+
+	a, err := buildServeArgs(parsed)
+	if err != nil {
+		return err
+	}
+
+	runServeProxy(a)
+	return nil
+}
+
+// runServeProxy is the proxy-launch hook that runServeCommand invokes after
+// flag parsing. Replaceable from tests so serve_cmd_test.go can spy on the
+// Args struct without actually starting the proxy.
+//
+// In production this points at runProxyMode (defined in main.go), which is
+// the same launcher the transparent-wrapper path uses. The branch inside
+// runProxyMode that wraps the handler with /shutdown + idle-timeout fires
+// when a.Headless is true — i.e. exactly what the serve dispatcher sets it
+// to.
+var runServeProxy = func(a *Args) {
+	runProxyMode(a)
+}
+
+// buildServeArgs maps a parsed cmd.ParseResult into the Args struct that
+// runProxyMode consumes. The mapping is exhaustive over the flags declared
+// on serveCommand in commands.go; a flag-set parity test
+// (serve_cmd_test.go) catches drift in either direction.
+//
+// --idle-timeout is the only flag with strict parsing: an invalid duration
+// is returned as a fail-loud error (matching the legacy --idle-timeout root
+// flag's behaviour, including rejection of bare ints like "30" and empty
+// values like "--idle-timeout=").
+func buildServeArgs(r *cmd.ParseResult) (*Args, error) {
+	a := &Args{
+		Headless:    true,            // serve always runs headless
+		IdleTimeout: 30 * time.Minute, // matches the pre-#89 default
+	}
+
+	if r.Set["idle-timeout"] {
+		raw := r.Strings["idle-timeout"]
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("serve: --idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
+		}
+		a.IdleTimeout = d
+	}
+
+	a.Profile = r.Strings["profile"]
+	a.Verbose = r.Bools["verbose"]
+	a.LogFile = r.Strings["log-file"]
+	a.Upstream = r.Strings["upstream"]
+	a.ProxyAPIKey = r.Strings["proxy-api-key"]
+	a.TLSCert = r.Strings["tls-cert"]
+	a.TLSKey = r.Strings["tls-key"]
+	a.NoUpdateCheck = r.Bools["no-update-check"]
+
+	if r.Set["model"] {
+		a.Model = r.Strings["model"]
+		a.ModelSet = true
+	}
+
+	if r.Set["port"] {
+		raw := r.Strings["port"]
+		if raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("serve: --port: %q is not an integer", raw)
+			}
+			a.PortFlag = n
+		}
+	}
+
+	return a, nil
+}

--- a/serve_cmd_test.go
+++ b/serve_cmd_test.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServeCommandTreeParity verifies bidirectional parity between the
+// serveCommand declaration (commands.go) and the buildServeArgs mapping
+// (serve_cmd.go). Mirrors hooks_cmd_test.go's TestHooksCommandTreeParity
+// shape, adapted for a leaf command (no sub-subcommands).
+//
+// Bidirectional contract:
+//   - tree → mapper: every flag on serveCommand must be consumed by
+//     buildServeArgs (or by runServeCommand's --help short-circuit).
+//   - mapper → tree: every flag buildServeArgs consumes must be declared
+//     on serveCommand. Drift fails the test loudly.
+//
+// The expected set is hard-coded so adding a flag to serveCommand without
+// wiring it into buildServeArgs trips this check on the next test run.
+func TestServeCommandTreeParity(t *testing.T) {
+	expected := map[string]bool{
+		"idle-timeout":    true,
+		"profile":         true,
+		"port":            true,
+		"model":           true,
+		"upstream":        true,
+		"log-file":        true,
+		"verbose":         true,
+		"proxy-api-key":   true,
+		"tls-cert":        true,
+		"tls-key":         true,
+		"no-update-check": true,
+		"help":            true,
+	}
+
+	got := make(map[string]bool, len(serveCommand.Flags))
+	for _, f := range serveCommand.AllFlags() {
+		got[f.Name] = true
+	}
+
+	for name := range expected {
+		if !got[name] {
+			t.Errorf("serveCommand should declare --%s but does not", name)
+		}
+	}
+	for name := range got {
+		if !expected[name] {
+			t.Errorf("serveCommand declares --%s but the parity contract does not list it (add to expected, or remove from tree)", name)
+		}
+	}
+}
+
+// TestRootSubcommandsIncludeServe is the structural counterpart to the
+// breaking change in #89: rootCommand must declare serve so dispatch from
+// main.go (and shell completion) finds it. Removing serveCommand from
+// rootCommand.Subcommands flips this assertion to fail.
+func TestRootSubcommandsIncludeServe(t *testing.T) {
+	if rootCommand.Subcommand("serve") == nil {
+		t.Fatal("rootCommand has no `serve` subcommand — tree wiring lost")
+	}
+}
+
+// TestRootCommandLegacyHeadlessFlagsRemoved locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear on
+// rootCommand any more. If a future refactor accidentally re-adds one,
+// this test fires and points at the migration sub-issue.
+func TestRootCommandLegacyHeadlessFlagsRemoved(t *testing.T) {
+	declared := make(map[string]bool)
+	for _, f := range rootCommand.AllFlags() {
+		declared[f.Name] = true
+	}
+	for _, flag := range []string{"headless", "idle-timeout"} {
+		if declared[flag] {
+			t.Errorf("rootCommand still declares --%s after #89 migration; the user-facing flag must move to `serve`", flag)
+		}
+	}
+}
+
+// --- buildServeArgs unit tests ---
+//
+// These exercise the parsed-flag → Args mapping directly. Together with
+// TestServeCommandTreeParity, they form the safety net for "drift between
+// what the tree advertises and what the runner actually wires through".
+
+func TestBuildServeArgs_DefaultIdleTimeout(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Headless {
+		t.Error("expected Headless=true (serve always runs headless)")
+	}
+	if a.IdleTimeout != 30*time.Minute {
+		t.Errorf("expected default IdleTimeout=30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutSeconds(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30s"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 30*time.Second {
+		t.Errorf("expected 30s, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutMinutes(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "5m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutHours(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "1h"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != time.Hour {
+		t.Errorf("expected 1h, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEquals(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout=2h30m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 2*time.Hour+30*time.Minute {
+		t.Errorf("expected 2h30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutZeroDisables(t *testing.T) {
+	// Per AC: --idle-timeout 0 disables idle shutdown. time.ParseDuration
+	// accepts "0" as a zero-value duration.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "0"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected 0 (disabled), got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutBareIntRejected(t *testing.T) {
+	// Matches the legacy --idle-timeout root-flag behaviour: bare ints
+	// like "30" (no unit) are rejected as ambiguous.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for bare-int --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutGarbageRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30mins"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for '30mins' --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEmptyRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout="})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for empty --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_Profile(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--profile", "aidev"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.Profile != "aidev" {
+		t.Errorf("expected Profile=%q, got %q", "aidev", a.Profile)
+	}
+}
+
+func TestBuildServeArgs_Port(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--port", "9999"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.PortFlag != 9999 {
+		t.Errorf("expected PortFlag=9999, got %d", a.PortFlag)
+	}
+}
+
+func TestBuildServeArgs_Verbose(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"-v"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Verbose {
+		t.Error("expected Verbose=true for -v")
+	}
+}
+
+func TestBuildServeArgs_TLSPair(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--tls-cert", "/tmp/c.pem", "--tls-key", "/tmp/k.pem"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.TLSCert != "/tmp/c.pem" || a.TLSKey != "/tmp/k.pem" {
+		t.Errorf("expected TLS cert/key wired, got cert=%q key=%q", a.TLSCert, a.TLSKey)
+	}
+}
+
+func TestBuildServeArgs_Model(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--model", "databricks-gpt-5-4-mini"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true when --model is passed")
+	}
+	if a.Model != "databricks-gpt-5-4-mini" {
+		t.Errorf("expected Model=%q, got %q", "databricks-gpt-5-4-mini", a.Model)
+	}
+}
+
+// TestBuildServeArgs_HeadlessAlwaysTrue is the AC-positive assertion: the
+// serve subcommand MUST set Headless=true on the Args it constructs. If
+// a future refactor accidentally drops this, runProxyMode would launch
+// codex as a child instead of running the proxy headlessly — the exact
+// silent-degradation hazard the issue's "byte-identical behavior" AC
+// guards against.
+func TestBuildServeArgs_HeadlessAlwaysTrue(t *testing.T) {
+	cases := [][]string{
+		{},                                     // bare serve
+		{"--idle-timeout", "5m"},               // typical IDE invocation
+		{"--profile", "aidev", "--port", "0"},  // edge values
+		{"--verbose"},                          // debug toggle
+	}
+	for _, args := range cases {
+		r, _ := serveCommand.Parse(args)
+		a, err := buildServeArgs(r)
+		if err != nil {
+			t.Errorf("buildServeArgs(%v) error: %v", args, err)
+			continue
+		}
+		if !a.Headless {
+			t.Errorf("buildServeArgs(%v): Headless should be true; serve always runs headless", args)
+		}
+	}
+}
+
+// --- runServeCommand integration tests (with spy) ---
+//
+// runServeCommand calls runServeProxy → runProxyMode. The latter does I/O
+// (proxy bind, auth check, codex lookup) we don't want in unit tests, so
+// these tests swap runServeProxy for a spy that captures the Args struct.
+// This is the "AC-positive" pattern called out in the issue's pitfalls
+// section: assert what the new code path actually does, not just "no
+// error raised".
+
+func TestRunServeCommand_HelpReturnsNilWithoutLaunching(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--help"}); err != nil {
+		t.Errorf("runServeCommand([--help]) returned error: %v", err)
+	}
+	if called {
+		t.Error("--help short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_HelpShortAliasReturnsNil(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"-h"}); err != nil {
+		t.Errorf("runServeCommand([-h]) returned error: %v", err)
+	}
+	if called {
+		t.Error("-h short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_InvalidIdleTimeoutReturnsError(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	err := runServeCommand([]string{"--idle-timeout", "not-a-duration"})
+	if err == nil {
+		t.Fatal("expected error for invalid --idle-timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "idle-timeout") {
+		t.Errorf("error %q should mention idle-timeout", err)
+	}
+	if called {
+		t.Error("invalid flag must NOT call runServeProxy")
+	}
+}
+
+// TestRunServeCommand_BareServeInvokesProxyWithDefaults exercises the
+// happy path: bare `databricks-codex serve` (no flags) must call
+// runProxyMode with Headless=true and the default 30m idle timeout. Catches
+// the regression where runServeCommand returns early without invoking the
+// launcher.
+func TestRunServeCommand_BareServeInvokesProxyWithDefaults(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{}); err != nil {
+		t.Fatalf("runServeCommand([]) returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 30*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 30m (default)", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesIdleTimeoutThrough is the headline AC test:
+// `databricks-codex serve --idle-timeout 5m` must reach runProxyMode with
+// IdleTimeout=5m. Asserts the FULL pipeline (parse → buildServeArgs →
+// runServeProxy) — a regression in any step fails this. This is the
+// positive assertion the issue's pitfalls section calls out: "serve
+// invokes runHeadless with idle-timeout=5m via a fake/spy, not 'no error
+// raised'".
+func TestRunServeCommand_PassesIdleTimeoutThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--idle-timeout", "5m"}); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 5*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 5m", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesAllFlagsThrough exercises the full mapping:
+// every serve flag (except --help) must reach the Args struct. Catches
+// the case where a flag is added to serveCommand and the parity test
+// passes (because buildServeArgs has a corresponding name lookup) but the
+// value silently drops on the floor.
+func TestRunServeCommand_PassesAllFlagsThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	args := []string{
+		"--idle-timeout", "10m",
+		"--profile", "aidev",
+		"--port", "55555",
+		"--model", "test-model",
+		"--upstream", "https://gw.example.com/openai/v1",
+		"--log-file", "/tmp/serve.log",
+		"--verbose",
+		"--proxy-api-key", "secret",
+		"--tls-cert", "/tmp/c.pem",
+		"--tls-key", "/tmp/k.pem",
+		"--no-update-check",
+	}
+	if err := runServeCommand(args); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+
+	checks := []struct {
+		name      string
+		got, want interface{}
+	}{
+		{"Headless", captured.Headless, true},
+		{"IdleTimeout", captured.IdleTimeout, 10 * time.Minute},
+		{"Profile", captured.Profile, "aidev"},
+		{"PortFlag", captured.PortFlag, 55555},
+		{"Model", captured.Model, "test-model"},
+		{"ModelSet", captured.ModelSet, true},
+		{"Upstream", captured.Upstream, "https://gw.example.com/openai/v1"},
+		{"LogFile", captured.LogFile, "/tmp/serve.log"},
+		{"Verbose", captured.Verbose, true},
+		{"ProxyAPIKey", captured.ProxyAPIKey, "secret"},
+		{"TLSCert", captured.TLSCert, "/tmp/c.pem"},
+		{"TLSKey", captured.TLSKey, "/tmp/k.pem"},
+		{"NoUpdateCheck", captured.NoUpdateCheck, true},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("Args.%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestHeadlessEnsureConfig_UsesServeSubcommand is the load-bearing test
+// for AC #5: "Hook entry must continue to bring the proxy up correctly —
+// the headlessEnsure-equivalent path now reuses the `serve` codepath
+// internally, not the removed --headless flag."
+//
+// pkg/headless.buildArgs uses Config.EnsureCommand as the prefix. With
+// EnsureCommand=["serve"], the spawned subprocess is `databricks-codex
+// serve --port=N [--tls-cert=... --tls-key=...]`. With EnsureCommand
+// empty, it would default back to `databricks-codex --headless ...` —
+// which would IMMEDIATELY fail since #89 deletes that flag. This test
+// fails loudly if a future refactor drops the EnsureCommand field.
+func TestHeadlessEnsureConfig_UsesServeSubcommand(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{})
+	if len(cfg.EnsureCommand) == 0 {
+		t.Fatal("headlessEnsureConfig must set EnsureCommand so the spawned subprocess invokes a real subcommand (not the removed --headless flag)")
+	}
+	if cfg.EnsureCommand[0] != "serve" {
+		t.Errorf("expected EnsureCommand[0]=%q, got %q (#89: hook spawn must invoke `serve`)", "serve", cfg.EnsureCommand[0])
+	}
+}
+
+// TestHeadlessEnsureConfig_TLSPropagated verifies the TLS knobs from
+// persistent state reach the headless.Config so the spawned subprocess
+// gets --tls-cert / --tls-key flags. Locks the existing semantics — the
+// #89 EnsureCommand change must NOT regress TLS plumbing.
+func TestHeadlessEnsureConfig_TLSPropagated(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{TLSCert: "/tmp/c.pem", TLSKey: "/tmp/k.pem"})
+	if cfg.TLSCert != "/tmp/c.pem" || cfg.TLSKey != "/tmp/k.pem" {
+		t.Errorf("TLS state must reach headless.Config; got cert=%q key=%q", cfg.TLSCert, cfg.TLSKey)
+	}
+	if cfg.Scheme != "https" {
+		t.Errorf("Scheme should be https when TLSCert is set, got %q", cfg.Scheme)
+	}
+}
+
+// TestServeHelpRendersAllFlags is a smoke check that the serveHelpTemplate
+// string mentions each of the flag names declared on serveCommand.
+// Prevents the help text from drifting silently when a flag is added or
+// renamed in commands.go.
+func TestServeHelpRendersAllFlags(t *testing.T) {
+	for _, name := range []string{
+		"--idle-timeout", "--profile", "--port", "--model",
+		"--upstream", "--log-file", "--verbose",
+		"--proxy-api-key", "--tls-cert", "--tls-key",
+		"--no-update-check", "--help",
+	} {
+		if !strings.Contains(serveHelpTemplate, name) {
+			t.Errorf("serveHelpTemplate missing %q", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #89. Part of the umbrella restructure in #85.

Consolidates the two remaining root flags `--headless` and `--idle-timeout` under a discoverable `serve` subcommand. Mirrors databricks-claude #180 with a deliberately smaller scope: codex has no daemon mode (no LaunchAgent / systemd-user / schtasks equivalent), so install/uninstall/status sub-subcommands are deferred per the issue's "Out of scope."

## Behaviour

```
databricks-codex serve [--idle-timeout <dur>]    # was --headless [--idle-timeout]
```

- Default idle-timeout: 30m. `--idle-timeout 0` disables idle shutdown.
- `--headless` and `--idle-timeout` REMOVED from root (breaking change).
- `hooks session-start` continues to bring the proxy up correctly via the new `serve` codepath internally. The shared launcher is `runProxyMode` — both the legacy `--headless` path and the new dispatcher converge there, so the runtime lifecycle is byte-identical to the pre-#89 behaviour. `headlessEnsureConfig` (hooks.go) sets `EnsureCommand: []string{"serve"}` to override the pkg/headless default prefix.

## What changed

- **`serveCommand` declared** in `commands.go` alongside `configCommand` and `hooksCommand`. `serveHelpTemplate` const at the bottom of the file.
- **`serve_cmd.go` (new)** — `runServeCommand` dispatcher mirroring `runHooksCommand`'s shape but as a leaf (no sub-subcommands). Builds `*Args` with `Headless=true` + parsed `IdleTimeout` and forwards to `runServeProxy` → `runProxyMode`.
- **`runProxyMode` extraction** in `main.go` — the post-parseArgs body of `main()` lifted into a function so the serve dispatcher and the transparent-wrapper path share one call site.
- **`parseArgs`** no longer recognises `--headless` or `--idle-timeout`. The transparent-proxy default path (`databricks-codex` alone, `databricks-codex -- codex-args`) is unaffected.
- **`hooks.go`** — `headlessEnsureConfig` now passes `[]string{"serve"}` as `EnsureCommand`; the installed hook JSON continues to invoke `databricks-codex hooks session-start`, which spawns the new `serve` subcommand internally.
- **`completion_flags.go`** — `--headless` and `--idle-timeout` removed from the `order` slice; shell completion auto-wires `serve <TAB>` and `serve --idle-timeout <TAB>` via the recursive `rootCommand.CompletionSubcommands()` established in #86.
- **`README.md`** has the `## serve Subcommand` section at top-level heading depth + a breaking-change callout listing the removed flags.
- **`AGENTS.md`** updated to reflect the new shape.

## Tests

- `serve_cmd_test.go` — dispatcher unit tests with a `runServeProxy` spy: `TestRunServeCommand_PassesIdleTimeoutThrough`, `TestRunServeCommand_BareServeInvokesProxyWithDefaults`, `TestRunServeCommand_PassesAllFlagsThrough`, `TestBuildServeArgs_HeadlessAlwaysTrue`.
- `TestRootCommandLegacyHeadlessFlagsRemoved` pins the breaking surface (no `--headless`/`--idle-timeout` on root after #89).
- `TestHeadlessEnsureConfig_UsesServeSubcommand` pins AC #5 — the hooks-session-start → serve indirection.
- `TestParseArgs_Legacy{Headless,IdleTimeout}Passthrough` pins that the removed flags now pass through transparently to codex (rather than being rejected) — preserving the principle that unknown flags are codex's problem.
- `main_test.go` `TestHandleHelp_AllFlagsPresent` updated: `serve` now in the list; `--headless`/`--idle-timeout` removed.

`go build ./... && go vet ./... && go test ./... -count=1` green.

## Cross-lane review

Reviewed in fresh context via `delegate_task` (no self-approve). Verdict: **APPROVE**. 0 BLOCKER, 0 MAJOR, 3 MINOR (port-parsing strictness divergence, empty-`--port=` silently accepted, no convergence test for the wrapper path post-`runProxyMode` extraction), 1 NIT. All MINORs are polish-grade, not change-requesting.

## Pipeline

`autopilot ($14.38, 101 turns, ~65 min wall) → cross-lane review via delegate_task ($X, ~5 min) → PR`. Wave 3 of 3 in the umbrella restructure — last codex sub-issue before #85 can flip to ready.
