### PR TITLE
feat: stop appending codex --help, document -- passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ databricks-codex --upstream https://adb-123456789.azuredatabricks.net/ai-gateway
 | `--tls-cert` | | TLS certificate file for the local proxy (requires `--tls-key`) |
 | `--tls-key` | | TLS private key file for the local proxy (requires `--tls-cert`) |
 | `--version` | | Print version and exit |
-| `--help`, `-h` | | Print wrapper flags and the full `codex --help` output, then exit |
+| `--help`, `-h` | | Print wrapper flags and exit. To see codex's own help, use `databricks-codex -- --help` (the `--` separator forwards everything after it to codex unchanged) |
 
 Headless / idle-timeout knobs live under `databricks-codex serve` (see [`serve` Subcommand](#serve-subcommand)).
 Hook installation lives under `databricks-codex hooks` (see [`hooks` Subcommand](#hooks-subcommand)).
@@ -195,7 +195,14 @@ This lets the wrapper:
 
 ### View full usage
 
-`databricks-codex --help` (or `-h`) prints the wrapper's own flags followed by the complete `codex --help` output.
+`databricks-codex --help` (or `-h`) prints the wrapper's own flags and exits. It does **not** append `codex --help` — mixing the two made it impossible to tell which flags belong to the wrapper vs the agent. To see codex's own help, use the `--` separator:
+
+```sh
+databricks-codex -- --help                # forwards --help to codex unchanged
+databricks-codex -- --model o3 -p "hi"    # forwards extra flags to codex
+```
+
+Anything after `--` is passed to `codex` verbatim.
 
 ## serve Subcommand
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -108,7 +107,7 @@ func main() {
 	}
 
 	if a.ShowHelp {
-		handleHelp(a.Upstream)
+		handleHelp()
 		os.Exit(0)
 	}
 
@@ -612,8 +611,13 @@ func parseArgs(args []string) (*Args, error) {
 	return a, nil
 }
 
-// handleHelp prints the databricks-codex help section, then execs codex --help.
-func handleHelp(upstreamBinary string) {
+// handleHelp prints the databricks-codex help. It does NOT exec
+// `codex --help` — appending the agent's help below the wrapper's made it
+// impossible to tell which flags the wrapper owns vs which it forwards.
+// Codex's own help is reachable via the existing `--` separator:
+//
+//	databricks-codex -- --help
+func handleHelp() {
 	fmt.Printf(`databricks-codex v%s — Databricks AI Gateway wrapper for OpenAI Codex CLI
 
 Patches ~/.codex/config.toml and runs a local proxy so the Codex CLI
@@ -643,28 +647,12 @@ Subcommands:
   hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
   serve [flags]                Run the proxy in headless mode (consolidates the deleted root flags)
 
-────────────────────────────────────────────────────────────────────────────────
-Codex CLI Options:
+Passthrough to codex:
+  Anything after a "--" separator is forwarded to the codex CLI unchanged.
+  Examples:
+    databricks-codex -- --help                # show codex's own help
+    databricks-codex -- --model o3 -p "hi"    # run codex with extra flags
 `, Version)
-
-	claudeBin := upstreamBinary
-	if claudeBin == "" {
-		if p, err := exec.LookPath("codex"); err == nil {
-			claudeBin = p
-		}
-	}
-
-	if claudeBin == "" {
-		fmt.Println("(codex binary not found on PATH — install from https://openai.com/codex)")
-		return
-	}
-
-	var buf bytes.Buffer
-	cmd := exec.Command(claudeBin, "--help")
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	_ = cmd.Run()
-	fmt.Print(buf.String())
 }
 
 // buildUpdaterConfig returns the standard updater.Config for databricks-codex.

--- a/main_test.go
+++ b/main_test.go
@@ -166,6 +166,20 @@ func TestParseArgs_Separator(t *testing.T) {
 	}
 }
 
+// TestParseArgs_SeparatorForwardsHelp locks #95: "--" terminates wrapper
+// flag parsing, so "-- --help" must NOT trigger the wrapper's help and must
+// forward "--help" to codex verbatim. Together with handleHelp no longer
+// shelling out to `codex --help`, this is how users reach codex's own help.
+func TestParseArgs_SeparatorForwardsHelp(t *testing.T) {
+	a := mustParseArgs(t, []string{"--", "--help"})
+	if a.ShowHelp {
+		t.Error("expected ShowHelp=false when --help appears after --")
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--help" {
+		t.Errorf("expected CodexArgs=[--help], got %v", a.CodexArgs)
+	}
+}
+
 func TestParseArgs_PassthroughArgs(t *testing.T) {
 	a := mustParseArgs(t, []string{"prompt text", "--unknown-flag", "gpt-4"})
 	if len(a.CodexArgs) != 3 {
@@ -446,7 +460,7 @@ func TestHandlePrintEnv_ContainsModel(t *testing.T) {
 
 func TestHandleHelp_ContainsDatabricksCodex(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, "databricks-codex") {
 		t.Errorf("expected help output to contain 'databricks-codex', got:\n%s", out)
@@ -455,26 +469,35 @@ func TestHandleHelp_ContainsDatabricksCodex(t *testing.T) {
 
 func TestHandleHelp_ContainsConfigSubcommand(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, "config") {
 		t.Errorf("expected help output to advertise the config subcommand, got:\n%s", out)
 	}
 }
 
-func TestHandleHelp_ContainsCodexCLISeparator(t *testing.T) {
+// TestHandleHelp_DocumentsPassthrough locks #95: wrapper help must NOT
+// append codex's own --help, and MUST document the `--` passthrough escape
+// hatch so users still know how to reach codex's flags.
+func TestHandleHelp_DocumentsPassthrough(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
-	if !strings.Contains(out, "Codex CLI Options:") {
-		t.Errorf("expected help output to contain 'Codex CLI Options:', got:\n%s", out)
+	if strings.Contains(out, "Codex CLI Options:") {
+		t.Errorf("wrapper help must not append codex --help under a 'Codex CLI Options:' divider, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Passthrough to codex:") {
+		t.Errorf("expected help output to document the -- passthrough, got:\n%s", out)
+	}
+	if !strings.Contains(out, "databricks-codex -- --help") {
+		t.Errorf("expected help output to show the `-- --help` example, got:\n%s", out)
 	}
 }
 
 func TestHandleHelp_NoBareNumberMinutesWording(t *testing.T) {
 	// Per #70: help text must not advertise the bare-int minutes shortcut.
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if strings.Contains(out, "bare number = minutes") {
 		t.Errorf("help text should no longer advertise 'bare number = minutes', got:\n%s", out)
@@ -533,7 +556,7 @@ func TestParseArgs_NoUpdateCheck(t *testing.T) {
 
 func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	// Legacy hook flags (--install-hooks / --uninstall-hooks /
 	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
@@ -553,7 +576,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 // root help text. If a future refactor re-adds them, this test fires.
 func TestHandleHelp_LegacyHeadlessFlagsAbsent(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	for _, flag := range []string{"--headless", "--idle-timeout"} {
 		if strings.Contains(out, flag) {
@@ -565,7 +588,7 @@ func TestHandleHelp_LegacyHeadlessFlagsAbsent(t *testing.T) {
 func TestHandleHelp_LegacyOtelFlagsAbsent(t *testing.T) {
 	// Locks the breaking surface: #87 removed these from the root.
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	for _, flag := range []string{"--otel", "--no-otel", "--no-otel-metrics", "--no-otel-logs", "--otel-metrics-table", "--otel-logs-table", "--print-env"} {
 		if strings.Contains(out, flag) {
@@ -576,7 +599,7 @@ func TestHandleHelp_LegacyOtelFlagsAbsent(t *testing.T) {
 
 func TestHandleHelp_ContainsVersion(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, fmt.Sprintf("databricks-codex v%s", Version)) {
 		t.Errorf("expected help output to contain version string, got:\n%s", out)


### PR DESCRIPTION
## Summary

`databricks-codex --help` previously printed the wrapper's flags then shelled out to `codex --help` and appended its output below a divider. Mixing the two surfaces made it impossible for users to tell which flags the wrapper owns vs which it forwards.

### Changes
- `handleHelp()` now renders only the wrapper help — no upstream binary exec
- Help template documents the existing `--` passthrough escape hatch (`databricks-codex -- --help`)
- README updated to match
- Tests: `TestParseArgs_SeparatorForwardsHelp` + `TestHandleHelp_DocumentsPassthrough`

Brings parity with databricks-claude's help behavior.

Closes #95
Cross-ref: IceRhymers/databricks-opencode#90