### PR TITLE
fix!: migrate to Codex profile-v2 config layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Transparent wrapper for the OpenAI Codex CLI that auto-injects Databricks OAuth 
 - Shim files (`lock.go`, `registry.go`, `process.go`, `proxy.go`) re-export or thin-wrap types from databricks-claude; keep them minimal
 - The resolution chain pattern (flag → env → saved state → default) is used for `profile`, `model`, and `otel-logs-table` — follow it precisely when adding new persistent flags
 - `modelSet bool` / `otelLogsTableSet bool` patterns distinguish explicit flags from defaults; new persistent flags need an analogous `*Set` variable
-- Never defer `cm.Restore()` — `os.Exit()` skips deferred calls; always call it explicitly before exit
+- **Write-once config model**: `tomlconfig.Patch` writes config.toml + sibling and returns. There is no Backup/Restore round-trip; do not add one back. Restore-on-exit was unreliable (os.Exit skips defers, panics/SIGKILL leave stale state, multi-session handoff races) and the same pattern in databricks-claude is also write-once.
 
 ### Testing Requirements
 - `make test` runs `go test ./... -v`

--- a/README.md
+++ b/README.md
@@ -242,6 +242,23 @@ databricks-codex serve --idle-timeout 0
 
 The SessionStart hook installed by `databricks-codex hooks install` spawns `databricks-codex serve` under the hood — you don't need to invoke this manually for the hooks path.
 
+### Using your own codex client against `serve`
+
+When you launch `codex` (TUI, GUI, or IDE extension) yourself against a `serve`-mode proxy — instead of going through the `databricks-codex` transparent wrapper — **you must tell codex to use the `databricks-proxy` profile** so it picks up the sibling config layer (`~/.codex/databricks-proxy.config.toml`) that points at the local proxy:
+
+```bash
+# TUI / one-shot exec
+codex --profile databricks-proxy "explain this codebase"
+codex exec --profile databricks-proxy "fix the bug in main.go"
+
+# Persist as the default profile so you don't have to type it every time
+codex config set profile databricks-proxy
+```
+
+For the **Codex GUI / IDE extension**, set the active profile to `databricks-proxy` in its settings — the wrapper `databricks-codex` (transparent mode) handles this for you automatically by prepending `--profile databricks-proxy`, but standalone `codex` invocations against a `serve`-mode proxy don't.
+
+> **Why:** Codex's profile-v2 layout (released 2026) requires the proxy config to live in a sibling file (`<profile>.config.toml`) selected by `--profile`, rather than as a root `profile = "..."` key in base `config.toml`. The transparent wrapper injects this flag; `serve` mode cannot, because it doesn't launch codex.
+
 ## `hooks` Subcommand
 
 Install hooks so every Codex session auto-starts the proxy on startup — no manual `databricks-codex serve` needed. Replaces the legacy root flags (`--install-hooks` / `--uninstall-hooks` / `--headless-ensure`), which were removed in v0.12.
@@ -281,6 +298,7 @@ Removes only the databricks-codex hook entries. Other hooks in your `hooks.json`
 - Safe to rerun `hooks install` after upgrades — existing hooks are replaced, not duplicated.
 - Custom port settings persist automatically via the state file (`~/.codex/.databricks-codex.json`).
 - `hooks session-start` is wired by `hooks install` for you; running it manually is a no-op when the proxy is already up.
+- **Codex profile selection:** the SessionStart hook only spawns the proxy — your codex client (TUI/GUI/extension) still needs to use the `databricks-proxy` profile to route through it. See [Using your own codex client against `serve`](#using-your-own-codex-client-against-serve) above. The simplest setup is `codex config set profile databricks-proxy` once, then plain `codex` always uses the proxy.
 
 ## Shell Tab Completions
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ This lets the wrapper:
 - Keep Codex pointed at a stable local endpoint while upstream credentials rotate
 - Support multiple concurrent sessions — first session owns the port, others join; last session out closes the listener
 
+`~/.codex/config.toml` is **write-once**: at session start we write our managed keys and sections (root `model_provider`, root `model`, `[model_providers.databricks-proxy]`, `[otel]` when enabled) and leave them there. There's no restore-on-exit — restore was unreliable in practice (`os.Exit` skips deferred calls, panics or `SIGKILL` leave stale state behind, multi-session handoff makes "who restores" ambiguous), and the same design choice has already been validated in our sister project `databricks-claude`. All non-managed user content in `config.toml` is preserved byte-for-byte across our writes.
+
 ### Transport: SSE only, no WebSocket
 
 Codex's model client prefers a **WebSocket** transport for the Responses API and only falls back to HTTP/SSE when the WebSocket handshake fails or the provider opts out. The decision is controlled by a per-provider boolean flag (`supports_websockets`, default `false`):
@@ -224,7 +226,7 @@ wire_api            = "responses"
 supports_websockets = false
 ```
 
-Plus the profile-v2 sibling file at `~/.codex/databricks-proxy.config.toml` for the transparent-wrapper path that passes `--profile databricks-proxy`. Both paths converge on the same provider; the root keys exist so the GUI / raw `codex` (no profile) also routes through the proxy. Your original `model_provider` and `model` values are saved on Backup and restored on session exit.
+Plus the profile-v2 sibling file at `~/.codex/databricks-proxy.config.toml` for the transparent-wrapper path that passes `--profile databricks-proxy`. Both paths converge on the same provider; the root keys exist so the GUI / raw `codex` (no profile) also routes through the proxy. These writes are **permanent** — see the write-once note above. If you had a pre-existing root `model_provider` or `model` in `config.toml`, our write replaces it; restore it manually if you uninstall the wrapper.
 
 ### View full usage
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,39 @@ This lets the wrapper:
 - Keep Codex pointed at a stable local endpoint while upstream credentials rotate
 - Support multiple concurrent sessions — first session owns the port, others join; last session out closes the listener
 
+### Transport: SSE only, no WebSocket
+
+Codex's model client prefers a **WebSocket** transport for the Responses API and only falls back to HTTP/SSE when the WebSocket handshake fails or the provider opts out. The decision is controlled by a per-provider boolean flag (`supports_websockets`, default `false`):
+
+- [`codex-rs/core/src/client.rs:1601-1640`](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs#L1601-L1640) — `stream` method: tries WebSocket first when enabled, falls back to `stream_responses_api` (SSE) on `FallbackToHttp`.
+- [`codex-rs/core/src/client.rs:798-806`](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs#L798-L806) — `responses_websocket_enabled` gate.
+- [`codex-rs/model-provider-info/src/lib.rs:134-136`](https://github.com/openai/codex/blob/main/codex-rs/model-provider-info/src/lib.rs#L134-L136) — the `supports_websockets` field on `ModelProviderInfo`.
+
+The Databricks AI Gateway speaks **SSE** over `POST /v1/responses` and does **not** accept WebSocket upgrade requests — a Codex client that tries to upgrade will get HTTP 400 from upstream. `databricks-codex` explicitly writes `supports_websockets = false` into `[model_providers.databricks-proxy]` to keep Codex on the SSE path. **Do not flip this to `true`** in your own edits to `~/.codex/config.toml` — the wrapper rewrites the section idempotently at every session start, but any hand-edits in between will break the next session until then.
+
+This is the same code path for **TUI, GUI, and IDE extensions** — all three frontends run `codex-core`'s `ModelClient` and respect `supports_websockets`. The decision is per-provider, not per-frontend.
+
+### Root-level `model_provider` override (GUI / raw `codex` fix)
+
+The Codex GUI and certain IDE extensions don't honor profile-v2 layering — they read `model_provider` and `model` from the **root** of `~/.codex/config.toml`, not from the active profile. Without a root-level override they fall through to the built-in `openai` provider (where `supports_websockets = true` is hardcoded) and attempt a WebSocket upgrade against whatever base URL is configured, yielding HTTP 400 from Databricks.
+
+This is confirmed by upstream [openai/codex#13041](https://github.com/openai/codex/issues/13041) — the recommended workaround is exactly a root-level provider override. `databricks-codex` now writes both:
+
+```toml
+# Root of ~/.codex/config.toml
+model_provider = "databricks-proxy"
+model          = "<resolved model>"
+
+[model_providers.databricks-proxy]
+name                = "Databricks Proxy"
+base_url            = "http://127.0.0.1:49154"
+api_key             = "databricks-proxy"
+wire_api            = "responses"
+supports_websockets = false
+```
+
+Plus the profile-v2 sibling file at `~/.codex/databricks-proxy.config.toml` for the transparent-wrapper path that passes `--profile databricks-proxy`. Both paths converge on the same provider; the root keys exist so the GUI / raw `codex` (no profile) also routes through the proxy. Your original `model_provider` and `model` values are saved on Backup and restored on session exit.
+
 ### View full usage
 
 `databricks-codex --help` (or `-h`) prints the wrapper's own flags and exits. It does **not** append `codex --help` — mixing the two made it impossible to tell which flags belong to the wrapper vs the agent. To see codex's own help, use the `--` separator:

--- a/config.go
+++ b/config.go
@@ -33,6 +33,10 @@ func NewConfigManager() *ConfigManager {
 // managed keys and additive for new ones — so calling EnsureConfig with
 // the same proxy URL but different OTEL endpoints will correctly add or
 // update the `[otel]` section without disturbing user content.
+//
+// Write-once semantics: there is no Backup/Restore round-trip. Our
+// managed keys/sections live in config.toml until they're explicitly
+// removed (e.g. by a future `databricks-codex uninstall`).
 func (cm *ConfigManager) EnsureConfig(proxyURL, model string, modelExplicit bool, otelLogsEndpoint, otelMetricsEndpoint string) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -47,8 +51,10 @@ func (cm *ConfigManager) EnsureConfig(proxyURL, model string, modelExplicit bool
 		return err
 	}
 
-	// Clean up any stale backup from pre-v0.6.0 crash recovery.
+	// Clean up any stale backup from pre-v0.6.0 / pre-v2.0.0 installs
+	// that used the Backup/Restore round-trip.
 	os.Remove(cm.config.ConfigPath() + ".databricks-codex-backup")
+	os.Remove(cm.config.SiblingPath() + ".databricks-codex-backup")
 
 	log.Printf("databricks-codex: ensured config.toml (proxy: %s)", proxyURL)
 	return nil

--- a/pkg/tomlconfig/AGENTS.md
+++ b/pkg/tomlconfig/AGENTS.md
@@ -4,34 +4,33 @@
 # tomlconfig
 
 ## Purpose
-String-based surgical TOML manipulation for `~/.codex/config.toml`. Avoids any TOML parser dependency by operating on raw lines. Handles backup/restore, atomic writes, crash recovery, and multi-session proxy URL handoff. The "surgical" approach means only managed keys and sections are modified — all other user content is preserved byte-for-byte.
+String-based surgical TOML manipulation for `~/.codex/config.toml` + the profile-v2 sibling file (`~/.codex/databricks-proxy.config.toml`). Avoids any TOML parser dependency by operating on raw lines. **Write-once model**: `Patch` is idempotent and final — there is no Backup/Restore round-trip. The "surgical" approach means only managed keys and sections are modified — all other user content is preserved byte-for-byte. Atomic writes via temp + rename. Multi-session proxy URL handoff via `UpdateProxyURL`.
 
 ## Key Files
 
 | File | Description |
 |------|-------------|
-| `tomlconfig.go` | `Manager` struct with `Backup`, `Patch`, `Restore`, `RestoreFromBackup`, `UpdateProxyURL`; all patching helpers |
-| `tomlconfig_test.go` | Tests for patch/restore round-trips, surgical preservation, model resolution, crash recovery |
+| `tomlconfig.go` | `Manager` struct with `Patch` (write-once base + sibling), `UpdateProxyURL` (proxy handoff), and pure string helpers |
+| `tomlconfig_test.go` | Tests for the v2 layout: provider section, root model_provider/model override, sibling file, supports_websockets opt-out, legacy migration, OTEL section, proxy URL handoff |
 
 ## For AI Agents
 
 ### Working In This Directory
 - **No external dependencies** — this package must stay zero-dependency; use only stdlib
-- Managed root keys: `profile`. Managed sections: `profiles.databricks-proxy`, `model_providers.databricks-proxy`, `otel`
-- The `sentinel` constant (`\x00nil`) marks keys/sections that were absent before patching so they can be fully removed on restore
-- `origRootKeys` and `origSections` maps track what was changed; `Restore` only undoes those changes
-- Model line handling is special: `origModelLine` / `patchedModelVal` track the preserve-if-present logic for `model =` inside `[profiles.databricks-proxy]`
-- `inAnySection` scans backward for a `[section]` header to avoid mistaking section-level keys for root-level keys
+- **Write-once model** — no `Backup`, no `Restore`, no `RestoreFromBackup`. Patch is final. Restore-on-exit was unreliable (os.Exit skips defers, panics leave stale state) and is intentionally removed. Do not add it back.
+- Managed root keys: `model_provider`, `model`. Managed sections in base: `model_providers.databricks-proxy`, `otel`. Profile-v2 sibling file is fully owned by us.
+- Legacy v1 layout (`profile = "databricks-proxy"` root key, `[profiles.databricks-proxy]` section) is **stripped one-way** on Patch when present, migrating any model value forward into the sibling file. Stripping is irreversible — that's the whole point of moving to profile-v2.
+- Root `profile = "..."` keys belonging to OTHER profile names (e.g. user's `profile = "myprofile"`) are left alone — Codex profile-v2 rejects them, but that's a pre-existing user condition, not our concern.
 
 ### Testing Requirements
 - Run with `go test ./pkg/tomlconfig/... -v`
 - Tests use in-memory TOML strings and temp files — no mocking needed
-- Cover: round-trip (patch then restore produces identical original), surgical preservation (non-managed keys untouched), crash recovery (`RestoreFromBackup`), multi-session handoff (`UpdateProxyURL`)
+- Cover: v2 layout assertions (root keys, provider section, sibling file, supports_websockets), legacy migration (strip + carry forward), surgical preservation (non-managed keys untouched), OTEL section round-trip, proxy URL handoff
 
 ### Common Patterns
 - `atomicWrite`: write to `.config-*.tmp`, chmod 0600, then `os.Rename` into place
 - Section boundary detection: next line starting with `[` (but not `[[`) ends the current section
-- Backup file: `config.toml.databricks-codex-backup` — written on `Backup()`, removed on successful `Restore()`
+- Pure string helpers (`setRootKey`, `stripRootKey`, `setSection`, `stripSection`) take no Manager state — easier to reason about, easier to test
 
 ## Dependencies
 

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -1,6 +1,30 @@
 // Package tomlconfig manages the Codex CLI config.toml file.
 // It uses simple string-based manipulation rather than a full TOML parser,
 // keeping the zero-external-dependency constraint.
+//
+// Layout (Codex profile-v2):
+//
+//   ~/.codex/config.toml              — base user config. We own
+//                                       [model_providers.databricks-proxy]
+//                                       and [otel] here. Anything else
+//                                       (including a user-owned root
+//                                       `profile` key) is preserved
+//                                       byte-for-byte across Restore.
+//   ~/.codex/databricks-proxy.config.toml — profile-v2 sibling file. We
+//                                       own this file entirely. Contains
+//                                       `model_provider` and (when set)
+//                                       `model`. Codex is launched with
+//                                       `--profile databricks-proxy` so
+//                                       this layer is merged on top of
+//                                       base.
+//
+// Pre-v0.7 layouts that wrote `profile = "databricks-proxy"` and
+// `[profiles.databricks-proxy]` into base config.toml are rejected by
+// current Codex (see https://developers.openai.com/codex/config-advanced#profiles).
+// Patch() strips any leftover legacy keys from the user's base config and
+// migrates the model value forward into the sibling file. Restore() puts
+// the original legacy keys back so a session run by an older
+// databricks-codex still finds what it expects.
 package tomlconfig
 
 import (
@@ -20,22 +44,31 @@ type PatchConfig struct {
 	OTELMetricsEndpoint string // e.g., "http://127.0.0.1:54321/otel/v1/metrics"
 }
 
+// SiblingProfileName is the Codex profile-v2 name we register under, and
+// also the basename of the sibling file (`<name>.config.toml`).
+const SiblingProfileName = "databricks-proxy"
+
 // sentinel is stored in originals when a key/section was absent before patching.
 const sentinel = "\x00nil"
 
 // Manager reads, patches, and restores the Codex config.toml file.
 type Manager struct {
-	configPath string
-	backupPath string
-	original   []byte // saved original content for crash-recovery backup
+	configPath  string
+	backupPath  string
+	siblingPath string // ~/.codex/databricks-proxy.config.toml
+	siblingBak  string // sibling backup path for crash recovery
+	original    []byte // saved original config.toml content for crash-recovery backup
 
 	// Surgical restore state: tracks what we changed so Restore only undoes
 	// what we touched. Keys map to original line/block content, or sentinel
 	// if the key/section was absent before patching.
 	origRootKeys    map[string]string // root key name -> original line or sentinel
 	origSections    map[string]string // section header (e.g. "profiles.databricks-proxy") -> original block or sentinel
-	origModelLine   string            // original "model = ..." line in [profiles.databricks-proxy], or sentinel
-	patchedModelVal string            // model value we wrote (for preserve-if-present check)
+	patchedModelVal string            // model value we wrote into the sibling file
+
+	// Sibling-file restore state.
+	siblingOriginal []byte // saved content if sibling file existed pre-patch
+	siblingExisted  bool   // true if the sibling file existed pre-patch
 }
 
 // NewManager creates a new config.toml manager.
@@ -50,9 +83,12 @@ func NewManager(configPath string) *Manager {
 			configPath = filepath.Join(home, ".codex", "config.toml")
 		}
 	}
+	siblingPath := filepath.Join(filepath.Dir(configPath), SiblingProfileName+".config.toml")
 	return &Manager{
 		configPath:   configPath,
 		backupPath:   configPath + ".databricks-codex-backup",
+		siblingPath:  siblingPath,
+		siblingBak:   siblingPath + ".databricks-codex-backup",
 		origRootKeys: make(map[string]string),
 		origSections: make(map[string]string),
 	}
@@ -63,31 +99,51 @@ func (m *Manager) ConfigPath() string {
 	return m.configPath
 }
 
-// Backup reads the current config.toml and saves the original content
-// both in memory and to a backup file for crash recovery.
+// SiblingPath returns the path to the profile-v2 sibling file.
+func (m *Manager) SiblingPath() string {
+	return m.siblingPath
+}
+
+// Backup reads the current config.toml (and the sibling file, if any) and
+// saves the original content both in memory and to backup files for crash
+// recovery.
 func (m *Manager) Backup() error {
 	data, err := os.ReadFile(m.configPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			m.original = nil
-			return nil
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read config.toml: %w", err)
 		}
-		return fmt.Errorf("read config.toml: %w", err)
+		m.original = nil
+	} else {
+		m.original = data
+		if err := atomicWrite(m.backupPath, data); err != nil {
+			return fmt.Errorf("write backup: %w", err)
+		}
 	}
-	m.original = data
 
-	if err := atomicWrite(m.backupPath, data); err != nil {
-		return fmt.Errorf("write backup: %w", err)
+	sdata, err := os.ReadFile(m.siblingPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read sibling config: %w", err)
+		}
+		m.siblingOriginal = nil
+		m.siblingExisted = false
+	} else {
+		m.siblingOriginal = sdata
+		m.siblingExisted = true
+		if err := atomicWrite(m.siblingBak, sdata); err != nil {
+			return fmt.Errorf("write sibling backup: %w", err)
+		}
 	}
 	return nil
 }
 
-// managedRootKeys lists top-level keys we manage.
-var managedRootKeys = []string{"profile"}
-
-// managedSections lists section headers we manage.
+// managedSections lists section headers we manage in base config.toml.
+// [profiles.databricks-proxy] is intentionally NOT here: under Codex
+// profile-v2 it lives in the sibling file. We still STRIP a legacy
+// [profiles.databricks-proxy] from base config (recording the original
+// for Restore) so old installs migrate forward cleanly.
 var managedSections = []string{
-	"profiles.databricks-proxy",
 	"model_providers.databricks-proxy",
 	"otel",
 }
@@ -95,6 +151,9 @@ var managedSections = []string{
 // Patch performs surgical patching of config.toml: it reads the existing file,
 // saves originals for keys/sections it will touch, then injects/updates only
 // managed keys and sections. All non-managed content is preserved byte-for-byte.
+//
+// It also writes (overwriting any existing content) the profile-v2 sibling
+// file with model_provider + model.
 func (m *Manager) Patch(cfg PatchConfig) error {
 	content := ""
 	if m.original != nil {
@@ -103,13 +162,26 @@ func (m *Manager) Patch(cfg PatchConfig) error {
 		content = string(data)
 	}
 
-	// --- Save originals and patch root keys ---
-	content = m.patchRootKey(content, "profile", `"databricks-proxy"`)
+	// --- Strip legacy v1 leftovers from base config.toml ---
+	//
+	// Codex profile-v2 rejects ANY root `profile = ...` key whenever the
+	// merged config has one (codex-rs/core/src/config/mod.rs:2606), and
+	// also rejects a [profiles.X] table in base config when --profile X is
+	// active (codex-rs/config/src/loader/mod.rs:240). Strip both here so
+	// that launching codex with --profile databricks-proxy succeeds. The
+	// originals are recorded via the existing tracking so Restore() puts
+	// them back when our session ends.
+	rootProfileVal := findRootProfileValue(content)
+	if rootProfileVal == SiblingProfileName {
+		// Only strip our own legacy key. A user's unrelated
+		// `profile = "myprofile"` is left alone — codex profile-v2
+		// rejects it independently and that's a pre-existing
+		// condition, not something we should silently overwrite.
+		content = m.stripRootKey(content, "profile")
+	}
+	content = m.stripSection(content, "profiles.databricks-proxy")
 
-	// --- Parse sections for surgical section patching ---
-	content = m.patchSection(content, "profiles.databricks-proxy",
-		m.buildProfileSection(cfg))
-
+	// --- Sections we still own in base config.toml ---
 	content = m.patchSection(content, "model_providers.databricks-proxy",
 		m.buildProviderSection(cfg))
 
@@ -128,47 +200,77 @@ func (m *Manager) Patch(cfg PatchConfig) error {
 	if err := atomicWrite(m.configPath, []byte(content)); err != nil {
 		return fmt.Errorf("write patched config.toml: %w", err)
 	}
+
+	// --- Write the profile-v2 sibling file ---
+	siblingContent := m.buildSiblingFile(cfg, rootProfileVal)
+	if err := atomicWrite(m.siblingPath, []byte(siblingContent)); err != nil {
+		return fmt.Errorf("write sibling config: %w", err)
+	}
 	return nil
 }
 
-// buildProfileSection builds the [profiles.databricks-proxy] section body.
-// It implements preserve-if-present for the model key.
-func (m *Manager) buildProfileSection(cfg PatchConfig) string {
+// buildSiblingFile renders the profile-v2 layer file. Resolution chain for
+// the `model` value (mirrors pre-v0.7 buildProfileSection semantics, just
+// targeted at the sibling file):
+//
+//  1. existing sibling file's `model = ...` (preserve user-set value)
+//  2. legacy `[profiles.databricks-proxy] model = ...` from base config
+//     (migrate forward when upgrading from pre-v0.7)
+//  3. explicit --model flag value
+//  4. root-level `model = ...` in the original base config
+//  5. resolved fallback (cfg.Model) — only if non-empty
+//
+// legacyRootProfile is the value of the legacy root `profile = "X"` key in
+// base config.toml at Backup time, if any. Today only legacyRootProfile ==
+// "databricks-proxy" is interesting (it means a prior databricks-codex run
+// wrote it and we should ignore any cargo model lookup that depends on it).
+func (m *Manager) buildSiblingFile(cfg PatchConfig, legacyRootProfile string) string {
 	var b strings.Builder
+	b.WriteString("# Managed by databricks-codex. Do not edit by hand.\n")
+	b.WriteString("# See https://developers.openai.com/codex/config-advanced#profiles\n")
 	b.WriteString("model_provider = \"databricks-proxy\"\n")
 
-	// Preserve-if-present: check if user already has a model line in this section.
-	existingModel := m.findModelInSection(string(m.original), "profiles.databricks-proxy")
-	if existingModel != "" {
-		m.origModelLine = existingModel
-	} else {
-		m.origModelLine = sentinel
+	model := m.resolveSiblingModel(cfg, legacyRootProfile)
+	if model != "" {
+		b.WriteString(fmt.Sprintf("model = %q\n", model))
+		m.patchedModelVal = model
 	}
+	return b.String()
+}
+
+// resolveSiblingModel applies the model-value resolution chain. Pure func
+// (apart from reading m.siblingOriginal / m.original which are captured at
+// Backup time).
+func (m *Manager) resolveSiblingModel(cfg PatchConfig, legacyRootProfile string) string {
+	_ = legacyRootProfile // reserved for future migration heuristics
 
 	if cfg.ModelExplicit {
-		// User explicitly passed --model: always write it.
-		b.WriteString(fmt.Sprintf("model = %q\n", cfg.Model))
-		m.patchedModelVal = cfg.Model
-	} else if existingModel != "" {
-		// Preserve user's existing model line in the profile section as-is.
-		b.WriteString(existingModel + "\n")
-	} else {
-		// No explicit flag, no model in the profile section.
-		// Check root-level model — since we switch the active profile to
-		// databricks-proxy, the root-level model would be ignored by Codex.
-		// Carry it into the profile section so the user's choice is respected.
-		rootModel := m.findRootModel(string(m.original))
-		if rootModel != "" {
-			b.WriteString(fmt.Sprintf("model = %q\n", rootModel))
-			m.patchedModelVal = rootModel
-		} else if cfg.Model != "" {
-			// Fall back to the resolved model (saved state or built-in default).
-			b.WriteString(fmt.Sprintf("model = %q\n", cfg.Model))
-			m.patchedModelVal = cfg.Model
-		}
+		return cfg.Model
 	}
 
-	return b.String()
+	// 1. Preserve a model already in the sibling file (user may have
+	//    edited it, or a prior session wrote it).
+	if existing := findRootModelInString(string(m.siblingOriginal)); existing != "" {
+		return existing
+	}
+
+	// 2. Migrate a model from the legacy [profiles.databricks-proxy]
+	//    section in base config.toml, if a prior databricks-codex left
+	//    one behind.
+	if legacyModel := findModelInSectionString(string(m.original), "profiles.databricks-proxy"); legacyModel != "" {
+		return legacyModel
+	}
+
+	// 3. Carry forward a root-level model from base config.toml. Under
+	//    profile-v2 layering this would already be visible without us
+	//    writing it, but echoing it into the sibling makes the active
+	//    layer self-describing and matches pre-v0.7 behaviour.
+	if rootModel := findRootModelInString(string(m.original)); rootModel != "" {
+		return rootModel
+	}
+
+	// 4. Fall back to the resolved value (saved state or built-in default).
+	return cfg.Model
 }
 
 // buildProviderSection builds the [model_providers.databricks-proxy] section body.
@@ -201,37 +303,61 @@ func (m *Manager) buildOTELSection(cfg PatchConfig) string {
 	return b.String()
 }
 
-// patchRootKey finds a root-level key in the content, saves its original value,
-// and replaces or appends the managed value.
-func (m *Manager) patchRootKey(content, key, value string) string {
+// stripRootKey removes a root-level key if present, recording the original
+// line so Restore can put it back. If the key is absent, no tracking and
+// no mutation.
+func (m *Manager) stripRootKey(content, key string) string {
 	lines := strings.Split(content, "\n")
-	found := false
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
 			m.origRootKeys[key] = line
-			lines[i] = fmt.Sprintf("%s = %s", key, value)
-			found = true
+			return strings.Join(removeAt(lines, i), "\n")
+		}
+	}
+	return content
+}
+
+// stripSection removes a [section] from content if present, recording the
+// original block so Restore can put it back. If the section is absent, no
+// tracking and no mutation.
+func (m *Manager) stripSection(content, sectionName string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+	startIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			startIdx = i
 			break
 		}
 	}
-	if !found {
-		m.origRootKeys[key] = sentinel
-		// Prepend the root key at the top (after any leading comments/blank lines
-		// but before the first section).
-		insertIdx := 0
-		for i, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(trimmed, "[") {
-				insertIdx = i
-				break
-			}
-			insertIdx = i + 1
-		}
-		newLine := fmt.Sprintf("%s = %s", key, value)
-		lines = insertAt(lines, insertIdx, newLine)
+	if startIdx == -1 {
+		return content
 	}
-	return strings.Join(lines, "\n")
+	endIdx := len(lines)
+	for i := startIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			endIdx = i
+			break
+		}
+	}
+	m.origSections[sectionName] = strings.Join(lines[startIdx:endIdx], "\n")
+
+	// Drop a trailing blank line that typically separates sections so
+	// removing a mid-file section doesn't leave a double-blank gap.
+	if endIdx < len(lines) && strings.TrimSpace(lines[endIdx-1]) == "" {
+		// blank already part of the section we're dropping
+	} else if endIdx < len(lines) && strings.TrimSpace(lines[endIdx]) == "" {
+		endIdx++
+	}
+	if startIdx > 0 && strings.TrimSpace(lines[startIdx-1]) == "" {
+		startIdx--
+	}
+	newLines := make([]string, 0, len(lines))
+	newLines = append(newLines, lines[:startIdx]...)
+	newLines = append(newLines, lines[endIdx:]...)
+	return strings.Join(newLines, "\n")
 }
 
 // removeSection finds a [section] in the content and removes it entirely
@@ -354,9 +480,27 @@ func (m *Manager) patchSection(content, sectionName, body string) string {
 	return strings.Join(newLines, "\n")
 }
 
-// findRootModel returns the value of a root-level "model = ..." line (not inside any section).
-// Returns empty string if not found.
-func (m *Manager) findRootModel(content string) string {
+// findRootProfileValue returns the value of a root `profile = "X"` key, or "".
+func findRootProfileValue(content string) string {
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, "profile") && !inAnySection(lines, i) {
+			parts := strings.SplitN(trimmed, "=", 2)
+			if len(parts) == 2 {
+				return strings.Trim(strings.TrimSpace(parts[1]), `"`)
+			}
+		}
+	}
+	return ""
+}
+
+// findRootModelInString returns the value of a root-level `model = ...`
+// line (not inside any section). Returns empty string if not found.
+func findRootModelInString(content string) string {
 	if content == "" {
 		return ""
 	}
@@ -375,8 +519,9 @@ func (m *Manager) findRootModel(content string) string {
 	return ""
 }
 
-// findModelInSection looks for a "model = ..." line inside a named section.
-func (m *Manager) findModelInSection(content, sectionName string) string {
+// findModelInSectionString looks for a `model = ...` line inside a named
+// section, returning the *value* (not the full line). Empty if not found.
+func findModelInSectionString(content, sectionName string) string {
 	if content == "" {
 		return ""
 	}
@@ -397,7 +542,12 @@ func (m *Manager) findModelInSection(content, sectionName string) string {
 				// Distinguish "model" from "model_provider"
 				afterKey := strings.TrimPrefix(trimmed, "model")
 				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
-					return line
+					parts := strings.SplitN(trimmed, "=", 2)
+					if len(parts) == 2 {
+						val := strings.TrimSpace(parts[1])
+						val = strings.Trim(val, `"`)
+						return val
+					}
 				}
 			}
 		}
@@ -408,6 +558,11 @@ func (m *Manager) findModelInSection(content, sectionName string) string {
 // Restore performs surgical restoration: only removes/restores keys and sections
 // that we patched. Non-managed content is untouched.
 func (m *Manager) Restore() error {
+	// Restore the sibling file first — independent of base config.toml.
+	if err := m.restoreSiblingFile(); err != nil {
+		return err
+	}
+
 	// If we never had an original file and we added everything, remove the file.
 	if m.original == nil && allSentinels(m.origRootKeys) && allSentinels(m.origSections) {
 		os.Remove(m.configPath)
@@ -435,13 +590,6 @@ func (m *Manager) Restore() error {
 		content = m.restoreSection(content, sectionName, orig)
 	}
 
-	// Restore model line if it was absent before.
-	if m.origModelLine == sentinel {
-		content = m.removeModelFromSection(content, "profiles.databricks-proxy")
-	} else if m.origModelLine != "" && m.origModelLine != sentinel {
-		content = m.restoreModelInSection(content, "profiles.databricks-proxy", m.origModelLine)
-	}
-
 	// Clean up trailing whitespace.
 	content = strings.TrimRight(content, "\n") + "\n"
 
@@ -452,22 +600,64 @@ func (m *Manager) Restore() error {
 	return nil
 }
 
+// restoreSiblingFile restores the sibling profile-v2 file to its pre-patch
+// state: either rewriting the original contents, or removing the file we
+// created.
+func (m *Manager) restoreSiblingFile() error {
+	if m.siblingExisted {
+		if err := atomicWrite(m.siblingPath, m.siblingOriginal); err != nil {
+			return fmt.Errorf("restore sibling config: %w", err)
+		}
+	} else {
+		if err := os.Remove(m.siblingPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove sibling config: %w", err)
+		}
+	}
+	if err := os.Remove(m.siblingBak); err != nil && !os.IsNotExist(err) {
+		// Backup cleanup failure isn't fatal — log and continue.
+		log.Printf("databricks-codex: failed to remove sibling backup: %v", err)
+	}
+	return nil
+}
+
 // restoreRootKey restores a single root key to its original state.
 func (m *Manager) restoreRootKey(content, key, orig string) string {
+	if orig == sentinel {
+		// Was absent — strip whatever's there now.
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if isRootKey(trimmed, key) && !inAnySection(lines, i) {
+				return strings.Join(removeAt(lines, i), "\n")
+			}
+		}
+		return content
+	}
+
+	// Was present pre-patch — put the original line back. Two cases:
+	//   (a) the current content still has the key (e.g. an unrelated edit
+	//       left it intact): replace in place.
+	//   (b) the current content does NOT have the key (we stripped it in
+	//       Patch): re-insert near the top.
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
-			if orig == sentinel {
-				// Was absent — remove the line.
-				lines = removeAt(lines, i)
-			} else {
-				lines[i] = orig
-			}
+			lines[i] = orig
 			return strings.Join(lines, "\n")
 		}
 	}
-	return content
+	insertIdx := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			insertIdx = i
+			break
+		}
+		insertIdx = i + 1
+	}
+	lines = insertAt(lines, insertIdx, orig)
+	return strings.Join(lines, "\n")
 }
 
 // restoreSection restores a section to its original state.
@@ -482,8 +672,29 @@ func (m *Manager) restoreSection(content, sectionName, orig string) string {
 			break
 		}
 	}
+
+	// Helper: rebuild the lines slice with `replacement` (slice or nil for
+	// pure deletion) replacing [startIdx..endIdx).
+	splice := func(start, end int, replacement []string) string {
+		newLines := make([]string, 0, len(lines)-(end-start)+len(replacement))
+		newLines = append(newLines, lines[:start]...)
+		newLines = append(newLines, replacement...)
+		newLines = append(newLines, lines[end:]...)
+		return strings.Join(newLines, "\n")
+	}
+
 	if startIdx == -1 {
-		return content
+		// Section is absent from current content. If orig was a sentinel
+		// (it didn't exist pre-patch either), nothing to do. Otherwise we
+		// need to re-add it (we stripped it during Patch). Append at end.
+		if orig == sentinel {
+			return content
+		}
+		// Ensure trailing newline before append.
+		if !strings.HasSuffix(content, "\n") && content != "" {
+			content += "\n"
+		}
+		return content + "\n" + orig + "\n"
 	}
 
 	// Find section end.
@@ -503,114 +714,75 @@ func (m *Manager) restoreSection(content, sectionName, orig string) string {
 		if removeStart > 0 && strings.TrimSpace(lines[removeStart-1]) == "" {
 			removeStart--
 		}
-		newLines := make([]string, 0, len(lines))
-		newLines = append(newLines, lines[:removeStart]...)
-		newLines = append(newLines, lines[endIdx:]...)
-		return strings.Join(newLines, "\n")
+		return splice(removeStart, endIdx, nil)
 	}
 
 	// Restore original block.
-	origLines := strings.Split(orig, "\n")
-	newLines := make([]string, 0, len(lines))
-	newLines = append(newLines, lines[:startIdx]...)
-	newLines = append(newLines, origLines...)
-	newLines = append(newLines, lines[endIdx:]...)
-	return strings.Join(newLines, "\n")
+	return splice(startIdx, endIdx, strings.Split(orig, "\n"))
 }
 
-// removeModelFromSection removes the model line from a section.
-func (m *Manager) removeModelFromSection(content, sectionName string) string {
-	header := "[" + sectionName + "]"
-	lines := strings.Split(content, "\n")
-	inSection := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == header {
-			inSection = true
-			continue
-		}
-		if inSection {
-			if strings.HasPrefix(trimmed, "[") {
-				break
-			}
-			if strings.HasPrefix(trimmed, "model") && strings.Contains(trimmed, "=") {
-				afterKey := strings.TrimPrefix(trimmed, "model")
-				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
-					lines = removeAt(lines, i)
-					return strings.Join(lines, "\n")
-				}
-			}
-		}
-	}
-	return content
-}
-
-// restoreModelInSection restores the model line in a section to its original value.
-func (m *Manager) restoreModelInSection(content, sectionName, origLine string) string {
-	header := "[" + sectionName + "]"
-	lines := strings.Split(content, "\n")
-	inSection := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == header {
-			inSection = true
-			continue
-		}
-		if inSection {
-			if strings.HasPrefix(trimmed, "[") {
-				break
-			}
-			if strings.HasPrefix(trimmed, "model") && strings.Contains(trimmed, "=") {
-				afterKey := strings.TrimPrefix(trimmed, "model")
-				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
-					lines[i] = origLine
-					return strings.Join(lines, "\n")
-				}
-			}
-		}
-	}
-	return content
-}
-
-// RestoreFromBackup recovers from a crash by restoring from the backup file.
-// Returns false if no backup exists (clean state).
-func (m *Manager) RestoreFromBackup() bool {
-	data, err := os.ReadFile(m.backupPath)
-	if err != nil {
-		return false
-	}
-	log.Printf("databricks-codex: restoring config.toml from crash backup")
-	m.original = data
-	// For crash recovery, do a full restore from backup.
-	if m.original == nil {
-		os.Remove(m.configPath)
-	} else {
-		if err := atomicWrite(m.configPath, m.original); err != nil {
-			log.Printf("databricks-codex: crash restore failed: %v", err)
-		}
-	}
-	os.Remove(m.backupPath)
-	return true
-}
-
-// UpdateProxyURL updates only the base_url in the managed config.toml.
-// Used for multi-session handoff.
+// UpdateProxyURL updates only the base_url in the provider section.
+// Used for multi-session handoff when an owner session ends and a survivor
+// rebinds the port: the proxy URL changes, but everything else stays.
 func (m *Manager) UpdateProxyURL(newURL string) error {
 	data, err := os.ReadFile(m.configPath)
 	if err != nil {
-		return fmt.Errorf("read config for proxy URL update: %w", err)
+		return fmt.Errorf("read config.toml: %w", err)
 	}
+	content := string(data)
 
-	lines := strings.Split(string(data), "\n")
+	lines := strings.Split(content, "\n")
+	inSection := false
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "base_url") && strings.Contains(trimmed, "=") {
-			lines[i] = fmt.Sprintf("base_url = %q", newURL)
-			break
+		if trimmed == "[model_providers.databricks-proxy]" {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			if strings.HasPrefix(trimmed, "base_url") {
+				lines[i] = fmt.Sprintf("base_url = %q", newURL)
+				break
+			}
 		}
 	}
 
 	return atomicWrite(m.configPath, []byte(strings.Join(lines, "\n")))
+}
+
+// RestoreFromBackup restores config.toml + sibling file from their backup
+// files if backups exist. Returns true if any restore was performed. Used
+// for crash recovery on next startup when a prior session left backups
+// behind without running Restore().
+func (m *Manager) RestoreFromBackup() bool {
+	restored := false
+
+	if data, err := os.ReadFile(m.backupPath); err == nil {
+		if err := atomicWrite(m.configPath, data); err == nil {
+			os.Remove(m.backupPath)
+			restored = true
+		}
+	}
+
+	if data, err := os.ReadFile(m.siblingBak); err == nil {
+		if err := atomicWrite(m.siblingPath, data); err == nil {
+			os.Remove(m.siblingBak)
+			restored = true
+		}
+	} else if os.IsNotExist(err) {
+		// No backup → sibling file is ours from this aborted session;
+		// remove it if present so it doesn't linger.
+		if _, statErr := os.Stat(m.siblingPath); statErr == nil {
+			if rerr := os.Remove(m.siblingPath); rerr == nil {
+				restored = true
+			}
+		}
+	}
+
+	return restored
 }
 
 // --- Helpers ---

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -2,29 +2,51 @@
 // It uses simple string-based manipulation rather than a full TOML parser,
 // keeping the zero-external-dependency constraint.
 //
-// Layout (Codex profile-v2):
+// Write-once semantics
+// ====================
 //
-//   ~/.codex/config.toml              — base user config. We own
-//                                       [model_providers.databricks-proxy]
-//                                       and [otel] here. Anything else
-//                                       (including a user-owned root
-//                                       `profile` key) is preserved
-//                                       byte-for-byte across Restore.
+// This package implements a write-once model: Patch() is idempotent and
+// final. There is NO Backup/Restore round-trip. The proxy lifecycle does
+// not own the user's config.toml across sessions — once we write it, our
+// managed keys/sections stay (re-emitted at every session start), and
+// non-managed user content is preserved byte-for-byte.
+//
+// Rationale: restore-on-exit was unreliable in practice (os.Exit skips
+// deferred calls, panics or SIGKILL leave the user with a stale config,
+// multi-session handoff races make "who restores" ambiguous). The same
+// pattern in databricks-claude was already write-once for the same
+// reason. Users who want to remove our managed keys can do so manually
+// or by uninstalling the wrapper — we do not silently revert their
+// config behind their back.
+//
+// Layout (Codex profile-v2 + GUI root-key fix)
+// ============================================
+//
+//   ~/.codex/config.toml              — base user config. We own:
+//                                       - root `model_provider`
+//                                       - root `model`
+//                                       - [model_providers.databricks-proxy]
+//                                       - [otel]
+//                                       Anything else (including a
+//                                       user-owned root `profile` key)
+//                                       is preserved byte-for-byte.
 //   ~/.codex/databricks-proxy.config.toml — profile-v2 sibling file. We
 //                                       own this file entirely. Contains
 //                                       `model_provider` and (when set)
 //                                       `model`. Codex is launched with
 //                                       `--profile databricks-proxy` so
 //                                       this layer is merged on top of
-//                                       base.
+//                                       base for the transparent-wrapper
+//                                       path; the GUI and raw `codex`
+//                                       use the root keys instead
+//                                       (openai/codex#13041).
 //
 // Pre-v0.7 layouts that wrote `profile = "databricks-proxy"` and
 // `[profiles.databricks-proxy]` into base config.toml are rejected by
 // current Codex (see https://developers.openai.com/codex/config-advanced#profiles).
-// Patch() strips any leftover legacy keys from the user's base config and
-// migrates the model value forward into the sibling file. Restore() puts
-// the original legacy keys back so a session run by an older
-// databricks-codex still finds what it expects.
+// Patch() strips any leftover legacy keys from the user's base config
+// and migrates the model value forward into the sibling file. Stripping
+// is one-way — the legacy keys do not come back.
 package tomlconfig
 
 import (
@@ -48,27 +70,11 @@ type PatchConfig struct {
 // also the basename of the sibling file (`<name>.config.toml`).
 const SiblingProfileName = "databricks-proxy"
 
-// sentinel is stored in originals when a key/section was absent before patching.
-const sentinel = "\x00nil"
-
-// Manager reads, patches, and restores the Codex config.toml file.
+// Manager reads and patches the Codex config.toml file plus the
+// profile-v2 sibling file. Write-once — no backup, no restore.
 type Manager struct {
 	configPath  string
-	backupPath  string
 	siblingPath string // ~/.codex/databricks-proxy.config.toml
-	siblingBak  string // sibling backup path for crash recovery
-	original    []byte // saved original config.toml content for crash-recovery backup
-
-	// Surgical restore state: tracks what we changed so Restore only undoes
-	// what we touched. Keys map to original line/block content, or sentinel
-	// if the key/section was absent before patching.
-	origRootKeys    map[string]string // root key name -> original line or sentinel
-	origSections    map[string]string // section header (e.g. "profiles.databricks-proxy") -> original block or sentinel
-	patchedModelVal string            // model value we wrote into the sibling file
-
-	// Sibling-file restore state.
-	siblingOriginal []byte // saved content if sibling file existed pre-patch
-	siblingExisted  bool   // true if the sibling file existed pre-patch
 }
 
 // NewManager creates a new config.toml manager.
@@ -83,66 +89,23 @@ func NewManager(configPath string) *Manager {
 			configPath = filepath.Join(home, ".codex", "config.toml")
 		}
 	}
-	siblingPath := filepath.Join(filepath.Dir(configPath), SiblingProfileName+".config.toml")
 	return &Manager{
-		configPath:   configPath,
-		backupPath:   configPath + ".databricks-codex-backup",
-		siblingPath:  siblingPath,
-		siblingBak:   siblingPath + ".databricks-codex-backup",
-		origRootKeys: make(map[string]string),
-		origSections: make(map[string]string),
+		configPath:  configPath,
+		siblingPath: filepath.Join(filepath.Dir(configPath), SiblingProfileName+".config.toml"),
 	}
 }
 
 // ConfigPath returns the path to config.toml.
-func (m *Manager) ConfigPath() string {
-	return m.configPath
-}
+func (m *Manager) ConfigPath() string { return m.configPath }
 
 // SiblingPath returns the path to the profile-v2 sibling file.
-func (m *Manager) SiblingPath() string {
-	return m.siblingPath
-}
+func (m *Manager) SiblingPath() string { return m.siblingPath }
 
-// Backup reads the current config.toml (and the sibling file, if any) and
-// saves the original content both in memory and to backup files for crash
-// recovery.
-func (m *Manager) Backup() error {
-	data, err := os.ReadFile(m.configPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("read config.toml: %w", err)
-		}
-		m.original = nil
-	} else {
-		m.original = data
-		if err := atomicWrite(m.backupPath, data); err != nil {
-			return fmt.Errorf("write backup: %w", err)
-		}
-	}
-
-	sdata, err := os.ReadFile(m.siblingPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("read sibling config: %w", err)
-		}
-		m.siblingOriginal = nil
-		m.siblingExisted = false
-	} else {
-		m.siblingOriginal = sdata
-		m.siblingExisted = true
-		if err := atomicWrite(m.siblingBak, sdata); err != nil {
-			return fmt.Errorf("write sibling backup: %w", err)
-		}
-	}
-	return nil
-}
-
-// managedSections lists section headers we manage in base config.toml.
+// managedSections lists section headers we own in base config.toml.
 // [profiles.databricks-proxy] is intentionally NOT here: under Codex
-// profile-v2 it lives in the sibling file. We still STRIP a legacy
-// [profiles.databricks-proxy] from base config (recording the original
-// for Restore) so old installs migrate forward cleanly.
+// profile-v2 it lives in the sibling file. Patch() STRIPS a legacy
+// [profiles.databricks-proxy] from base config (one-way migration) so
+// old installs become valid profile-v2 configs.
 var managedSections = []string{
 	"model_providers.databricks-proxy",
 	"otel",
@@ -167,140 +130,108 @@ var managedSections = []string{
 //     same values.
 //
 // We do NOT write a root `profile = "..."` key — Codex profile-v2 rejects
-// that (codex-rs/core/src/config/mod.rs:2606) and stripping it on Patch
-// is the migration path for users upgrading from pre-v0.7.
+// that (codex-rs/core/src/config/mod.rs:2606). Stripping it on Patch is
+// the migration path for users upgrading from pre-v0.7.
 var managedRootKeys = []string{"model_provider", "model"}
 
-// Patch performs surgical patching of config.toml: it reads the existing file,
-// saves originals for keys/sections it will touch, then injects/updates only
-// managed keys and sections. All non-managed content is preserved byte-for-byte.
-//
-// It also writes (overwriting any existing content) the profile-v2 sibling
-// file with model_provider + model.
+// Patch is the idempotent write-once entry point. It reads the current
+// config.toml (if any), strips legacy v1 keys we own, writes our root
+// keys + provider + otel sections, and overwrites the sibling file. All
+// non-managed user content is preserved byte-for-byte.
 func (m *Manager) Patch(cfg PatchConfig) error {
 	content := ""
-	if m.original != nil {
-		content = string(m.original)
-	} else if data, err := os.ReadFile(m.configPath); err == nil {
+	if data, err := os.ReadFile(m.configPath); err == nil {
 		content = string(data)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read config.toml: %w", err)
 	}
 
 	// --- Strip legacy v1 leftovers from base config.toml ---
 	//
 	// Codex profile-v2 rejects ANY root `profile = ...` key whenever the
 	// merged config has one (codex-rs/core/src/config/mod.rs:2606), and
-	// also rejects a [profiles.X] table in base config when --profile X is
-	// active (codex-rs/config/src/loader/mod.rs:240). Strip both here so
-	// that launching codex with --profile databricks-proxy succeeds. The
-	// originals are recorded via the existing tracking so Restore() puts
-	// them back when our session ends.
+	// also rejects a [profiles.X] table in base config when --profile X
+	// is active (codex-rs/config/src/loader/mod.rs:240). Strip both so
+	// the GUI/TUI/IDE all load successfully. This is a one-way
+	// migration — the legacy keys are not put back.
 	rootProfileVal := findRootProfileValue(content)
 	if rootProfileVal == SiblingProfileName {
 		// Only strip our own legacy key. A user's unrelated
 		// `profile = "myprofile"` is left alone — codex profile-v2
 		// rejects it independently and that's a pre-existing
 		// condition, not something we should silently overwrite.
-		content = m.stripRootKey(content, "profile")
+		content = stripRootKey(content, "profile")
 	}
-	content = m.stripSection(content, "profiles.databricks-proxy")
+	content = stripSection(content, "profiles.databricks-proxy")
 
 	// --- Root-level provider override (fixes GUI / raw codex paths) ---
-	//
-	// See managedRootKeys doc above. Root model_provider points at our
-	// proxy provider; root model is the resolved value (same as what we
-	// put in the sibling file). On Restore, the user's original root
-	// model/model_provider come back via origRootKeys.
-	content = m.patchRootKey(content, "model_provider", fmt.Sprintf("%q", SiblingProfileName))
-	rootModel := m.resolveSiblingModel(cfg, rootProfileVal)
-	if rootModel != "" {
-		content = m.patchRootKey(content, "model", fmt.Sprintf("%q", rootModel))
+	content = setRootKey(content, "model_provider", fmt.Sprintf("%q", SiblingProfileName))
+	resolvedModel := m.resolveModel(cfg, content)
+	if resolvedModel != "" {
+		content = setRootKey(content, "model", fmt.Sprintf("%q", resolvedModel))
 	}
 
-	// --- Sections we still own in base config.toml ---
-	content = m.patchSection(content, "model_providers.databricks-proxy",
+	// --- Sections we own in base config.toml ---
+	content = setSection(content, "model_providers.databricks-proxy",
 		m.buildProviderSection(cfg))
 
-	// Always handle the [otel] section: when both endpoints are set, patch
-	// it; when both are empty, remove it if it exists. This makes --no-otel
-	// (or --no-otel-metrics/--no-otel-logs that clears the last remaining
-	// signal) actually erase the section from config.toml — not just leave
-	// stale exporter lines behind.
+	// Always handle the [otel] section: when both endpoints are set,
+	// write it; when both are empty, remove it. This makes --no-otel
+	// actually erase the section from config.toml — not leave stale
+	// exporter lines behind.
 	if cfg.OTELLogsEndpoint != "" || cfg.OTELMetricsEndpoint != "" {
-		content = m.patchSection(content, "otel",
-			m.buildOTELSection(cfg))
+		content = setSection(content, "otel", m.buildOTELSection(cfg))
 	} else {
-		content = m.removeSection(content, "otel")
+		content = removeSection(content, "otel")
 	}
 
 	if err := atomicWrite(m.configPath, []byte(content)); err != nil {
-		return fmt.Errorf("write patched config.toml: %w", err)
+		return fmt.Errorf("write config.toml: %w", err)
 	}
 
-	// --- Write the profile-v2 sibling file ---
-	siblingContent := m.buildSiblingFile(cfg, rootProfileVal)
-	if err := atomicWrite(m.siblingPath, []byte(siblingContent)); err != nil {
+	// --- Write the profile-v2 sibling file (overwrite) ---
+	if err := atomicWrite(m.siblingPath, []byte(m.buildSiblingFile(resolvedModel))); err != nil {
 		return fmt.Errorf("write sibling config: %w", err)
 	}
 	return nil
 }
 
-// buildSiblingFile renders the profile-v2 layer file. Resolution chain for
-// the `model` value (mirrors pre-v0.7 buildProfileSection semantics, just
-// targeted at the sibling file):
+// resolveModel applies the model-value resolution chain. content is the
+// current base config.toml (post-strip) used to look up a root-level
+// model line. The sibling file is checked first so a user-edited or
+// previously-written value wins over our resolved default.
 //
-//  1. existing sibling file's `model = ...` (preserve user-set value)
-//  2. legacy `[profiles.databricks-proxy] model = ...` from base config
-//     (migrate forward when upgrading from pre-v0.7)
-//  3. explicit --model flag value
-//  4. root-level `model = ...` in the original base config
-//  5. resolved fallback (cfg.Model) — only if non-empty
+// Chain:
 //
-// legacyRootProfile is the value of the legacy root `profile = "X"` key in
-// base config.toml at Backup time, if any. Today only legacyRootProfile ==
-// "databricks-proxy" is interesting (it means a prior databricks-codex run
-// wrote it and we should ignore any cargo model lookup that depends on it).
-func (m *Manager) buildSiblingFile(cfg PatchConfig, legacyRootProfile string) string {
-	var b strings.Builder
-	b.WriteString("# Managed by databricks-codex. Do not edit by hand.\n")
-	b.WriteString("# See https://developers.openai.com/codex/config-advanced#profiles\n")
-	b.WriteString("model_provider = \"databricks-proxy\"\n")
-
-	model := m.resolveSiblingModel(cfg, legacyRootProfile)
-	if model != "" {
-		b.WriteString(fmt.Sprintf("model = %q\n", model))
-		m.patchedModelVal = model
-	}
-	return b.String()
-}
-
-// resolveSiblingModel applies the model-value resolution chain. Pure func
-// (apart from reading m.siblingOriginal / m.original which are captured at
-// Backup time).
-func (m *Manager) resolveSiblingModel(cfg PatchConfig, legacyRootProfile string) string {
-	_ = legacyRootProfile // reserved for future migration heuristics
-
+//	1. existing sibling file's `model = ...` (preserve user-set value)
+//	2. legacy `[profiles.databricks-proxy] model = ...` from a
+//	   pre-strip snapshot of base config (one-time migration)
+//	3. explicit --model flag value (cfg.ModelExplicit)
+//	4. root-level `model = ...` already in base config
+//	5. resolved fallback (cfg.Model) — only if non-empty
+func (m *Manager) resolveModel(cfg PatchConfig, currentBase string) string {
 	if cfg.ModelExplicit {
 		return cfg.Model
 	}
 
-	// 1. Preserve a model already in the sibling file (user may have
-	//    edited it, or a prior session wrote it).
-	if existing := findRootModelInString(string(m.siblingOriginal)); existing != "" {
-		return existing
+	// 1. Sibling file's existing model.
+	if sdata, err := os.ReadFile(m.siblingPath); err == nil {
+		if existing := findRootModelInString(string(sdata)); existing != "" {
+			return existing
+		}
 	}
 
-	// 2. Migrate a model from the legacy [profiles.databricks-proxy]
-	//    section in base config.toml, if a prior databricks-codex left
-	//    one behind.
-	if legacyModel := findModelInSectionString(string(m.original), "profiles.databricks-proxy"); legacyModel != "" {
-		return legacyModel
+	// 2. Legacy section migration: re-read the file from disk so we
+	//    see the [profiles.databricks-proxy] block before we stripped
+	//    it. currentBase has already had it removed.
+	if odata, err := os.ReadFile(m.configPath); err == nil {
+		if legacyModel := findModelInSectionString(string(odata), "profiles.databricks-proxy"); legacyModel != "" {
+			return legacyModel
+		}
 	}
 
-	// 3. Carry forward a root-level model from base config.toml. Under
-	//    profile-v2 layering this would already be visible without us
-	//    writing it, but echoing it into the sibling makes the active
-	//    layer self-describing and matches pre-v0.7 behaviour.
-	if rootModel := findRootModelInString(string(m.original)); rootModel != "" {
+	// 3. Root-level model in current base config.
+	if rootModel := findRootModelInString(currentBase); rootModel != "" {
 		return rootModel
 	}
 
@@ -308,7 +239,20 @@ func (m *Manager) resolveSiblingModel(cfg PatchConfig, legacyRootProfile string)
 	return cfg.Model
 }
 
-// buildProviderSection builds the [model_providers.databricks-proxy] section body.
+// buildSiblingFile renders the profile-v2 layer file. Caller resolves the
+// model value; passing "" omits the model line entirely.
+func (m *Manager) buildSiblingFile(model string) string {
+	var b strings.Builder
+	b.WriteString("# Managed by databricks-codex. Do not edit by hand.\n")
+	b.WriteString("# See https://developers.openai.com/codex/config-advanced#profiles\n")
+	b.WriteString("model_provider = \"databricks-proxy\"\n")
+	if model != "" {
+		b.WriteString(fmt.Sprintf("model = %q\n", model))
+	}
+	return b.String()
+}
+
+// buildProviderSection builds the [model_providers.databricks-proxy] body.
 //
 // supports_websockets = false is written explicitly (defensive — the serde
 // default is also false). Codex's model client prefers WebSocket transport
@@ -334,13 +278,11 @@ func (m *Manager) buildProviderSection(cfg PatchConfig) string {
 }
 
 // buildOTELSection builds the [otel] section body.
-// Emits `exporter` (logs) and/or `metrics_exporter` for whichever endpoints
-// are non-empty. Both can coexist in the same [otel] block.
 //
 // Note: Codex's upstream `metrics_exporter` default is Statsig
-// (https://ab.chatgpt.com/otlp/v1/metrics). We do NOT defensively rewrite
-// this at the proxy layer; setting `metrics_exporter` here is the user's
-// explicit opt-in to route metrics through Databricks instead.
+// (https://ab.chatgpt.com/otlp/v1/metrics). We do NOT defensively
+// rewrite this at the proxy layer; setting `metrics_exporter` here is
+// the user's explicit opt-in to route metrics through Databricks.
 func (m *Manager) buildOTELSection(cfg PatchConfig) string {
 	var b strings.Builder
 	b.WriteString("environment = \"production\"\n")
@@ -353,47 +295,52 @@ func (m *Manager) buildOTELSection(cfg PatchConfig) string {
 	return b.String()
 }
 
-// stripRootKey removes a root-level key if present, recording the original
-// line so Restore can put it back. If the key is absent, no tracking and
-// no mutation.
-func (m *Manager) stripRootKey(content, key string) string {
-	lines := strings.Split(content, "\n")
+// UpdateProxyURL updates only the base_url in the provider section.
+// Used for multi-session handoff when an owner session ends and a
+// survivor rebinds the port: the proxy URL changes, but everything
+// else stays.
+func (m *Manager) UpdateProxyURL(newURL string) error {
+	data, err := os.ReadFile(m.configPath)
+	if err != nil {
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	inSection := false
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
-			m.origRootKeys[key] = line
-			return strings.Join(removeAt(lines, i), "\n")
+		if trimmed == "[model_providers.databricks-proxy]" {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			if strings.HasPrefix(trimmed, "base_url") {
+				lines[i] = fmt.Sprintf("base_url = %q", newURL)
+				break
+			}
 		}
 	}
-	return content
+	return atomicWrite(m.configPath, []byte(strings.Join(lines, "\n")))
 }
 
-// patchRootKey writes (or overwrites) a root-level key to the given value,
-// recording the original for Restore. If the key was absent, sentinel is
-// recorded so Restore removes the line entirely. If it was present, the
-// original line is preserved verbatim so Restore can put it back exactly.
+// --- Pure string helpers (no Manager state) ---
+
+// setRootKey writes (or overwrites) a root-level key to the given value.
+// Pure write, no tracking. If the key was absent, the new line is
+// prepended above the first section header.
 //
 // value is the right-hand side of the assignment — callers are responsible
 // for quoting (e.g. fmt.Sprintf("%q", "foo")).
-func (m *Manager) patchRootKey(content, key, value string) string {
+func setRootKey(content, key, value string) string {
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
-			// Only record the FIRST patch's original — subsequent
-			// patches in the same session are overwriting our own
-			// previous write, not user content. If origRootKeys
-			// already has an entry we keep it.
-			if _, seen := m.origRootKeys[key]; !seen {
-				m.origRootKeys[key] = line
-			}
 			lines[i] = fmt.Sprintf("%s = %s", key, value)
 			return strings.Join(lines, "\n")
 		}
-	}
-	// Key absent — record sentinel, prepend at top (above first section).
-	if _, seen := m.origRootKeys[key]; !seen {
-		m.origRootKeys[key] = sentinel
 	}
 	insertIdx := 0
 	for i, line := range lines {
@@ -408,10 +355,22 @@ func (m *Manager) patchRootKey(content, key, value string) string {
 	return strings.Join(lines, "\n")
 }
 
-// stripSection removes a [section] from content if present, recording the
-// original block so Restore can put it back. If the section is absent, no
-// tracking and no mutation.
-func (m *Manager) stripSection(content, sectionName string) string {
+// stripRootKey removes a root-level key if present. No-op if absent.
+func stripRootKey(content, key string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
+			return strings.Join(removeAt(lines, i), "\n")
+		}
+	}
+	return content
+}
+
+// stripSection removes a [section] block if present. No-op if absent.
+// Also removes a blank line on either side of the removed block so we
+// don't leave a double-blank gap.
+func stripSection(content, sectionName string) string {
 	header := "[" + sectionName + "]"
 	lines := strings.Split(content, "\n")
 	startIdx := -1
@@ -432,12 +391,8 @@ func (m *Manager) stripSection(content, sectionName string) string {
 			break
 		}
 	}
-	m.origSections[sectionName] = strings.Join(lines[startIdx:endIdx], "\n")
-
-	// Drop a trailing blank line that typically separates sections so
-	// removing a mid-file section doesn't leave a double-blank gap.
 	if endIdx < len(lines) && strings.TrimSpace(lines[endIdx-1]) == "" {
-		// blank already part of the section we're dropping
+		// blank inside the block being removed — no-op
 	} else if endIdx < len(lines) && strings.TrimSpace(lines[endIdx]) == "" {
 		endIdx++
 	}
@@ -450,72 +405,18 @@ func (m *Manager) stripSection(content, sectionName string) string {
 	return strings.Join(newLines, "\n")
 }
 
-// removeSection finds a [section] in the content and removes it entirely
-// (header + body up to the next section header or EOF). The original block
-// is recorded in origSections so Restore() can put it back.
-//
-// If the section is not present, this is a no-op — and crucially, we do
-// NOT record a sentinel, because there's nothing to undo on Restore().
-func (m *Manager) removeSection(content, sectionName string) string {
-	header := "[" + sectionName + "]"
-	lines := strings.Split(content, "\n")
-
-	startIdx := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			startIdx = i
-			break
-		}
-	}
-
-	if startIdx == -1 {
-		// Section absent — nothing to remove, nothing to track.
-		return content
-	}
-
-	// Find section end (next section header or EOF).
-	endIdx := len(lines)
-	for i := startIdx + 1; i < len(lines); i++ {
-		trimmed := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
-			endIdx = i
-			break
-		}
-	}
-
-	// Save original block so Restore() can put it back if needed.
-	m.origSections[sectionName] = strings.Join(lines[startIdx:endIdx], "\n")
-
-	// Also drop the trailing blank line that typically separates sections,
-	// so removing [otel] doesn't leave a double-blank gap behind. Only do
-	// this if endIdx is followed by a blank line (i.e. we're removing a
-	// mid-file section, not a trailing one).
-	if endIdx < len(lines) && strings.TrimSpace(lines[endIdx-1]) == "" {
-		// endIdx-1 is already a blank line inside the section we're
-		// removing — nothing extra to do.
-	} else if endIdx < len(lines) && strings.TrimSpace(lines[endIdx]) == "" {
-		// The line right after the section is blank — consume it.
-		endIdx++
-	}
-	// Also drop a blank line immediately BEFORE the section if present,
-	// so we don't leave a dangling separator.
-	if startIdx > 0 && strings.TrimSpace(lines[startIdx-1]) == "" {
-		startIdx--
-	}
-
-	newLines := make([]string, 0, len(lines))
-	newLines = append(newLines, lines[:startIdx]...)
-	newLines = append(newLines, lines[endIdx:]...)
-
-	return strings.Join(newLines, "\n")
+// removeSection is a thin alias for stripSection, kept distinct only for
+// callsite-readability where we mean "user said disable, not migration".
+func removeSection(content, sectionName string) string {
+	return stripSection(content, sectionName)
 }
 
-// patchSection finds a [section] in the content, saves its original block,
-// and replaces or appends the managed section.
-func (m *Manager) patchSection(content, sectionName, body string) string {
+// setSection writes (or overwrites) a [section] with the given body.
+// Pure write, no tracking. If absent, appended at end with a leading
+// blank-line separator.
+func setSection(content, sectionName, body string) string {
 	header := "[" + sectionName + "]"
 	lines := strings.Split(content, "\n")
-
 	startIdx := -1
 	for i, line := range lines {
 		if strings.TrimSpace(line) == header {
@@ -523,22 +424,15 @@ func (m *Manager) patchSection(content, sectionName, body string) string {
 			break
 		}
 	}
-
 	if startIdx == -1 {
-		// Section absent — record sentinel, append.
-		m.origSections[sectionName] = sentinel
 		var sb strings.Builder
 		sb.WriteString(header + "\n")
 		sb.WriteString(body)
-		// Ensure content ends with newline before appending.
 		if !strings.HasSuffix(content, "\n") && content != "" {
 			content += "\n"
 		}
-		content += "\n" + sb.String()
-		return content
+		return content + "\n" + sb.String()
 	}
-
-	// Find section end (next section header or EOF).
 	endIdx := len(lines)
 	for i := startIdx + 1; i < len(lines); i++ {
 		trimmed := strings.TrimSpace(lines[i])
@@ -547,12 +441,6 @@ func (m *Manager) patchSection(content, sectionName, body string) string {
 			break
 		}
 	}
-
-	// Save original block.
-	origBlock := strings.Join(lines[startIdx:endIdx], "\n")
-	m.origSections[sectionName] = origBlock
-
-	// Build replacement.
 	var replacement []string
 	replacement = append(replacement, header)
 	for _, line := range strings.Split(body, "\n") {
@@ -560,13 +448,10 @@ func (m *Manager) patchSection(content, sectionName, body string) string {
 			replacement = append(replacement, line)
 		}
 	}
-
-	// Replace the section block.
 	newLines := make([]string, 0, len(lines))
 	newLines = append(newLines, lines[:startIdx]...)
 	newLines = append(newLines, replacement...)
 	newLines = append(newLines, lines[endIdx:]...)
-
 	return strings.Join(newLines, "\n")
 }
 
@@ -589,7 +474,7 @@ func findRootProfileValue(content string) string {
 }
 
 // findRootModelInString returns the value of a root-level `model = ...`
-// line (not inside any section). Returns empty string if not found.
+// line (not inside any section). Returns "" if not found.
 func findRootModelInString(content string) string {
 	if content == "" {
 		return ""
@@ -610,7 +495,7 @@ func findRootModelInString(content string) string {
 }
 
 // findModelInSectionString looks for a `model = ...` line inside a named
-// section, returning the *value* (not the full line). Empty if not found.
+// section, returning the *value*. Empty if not found.
 func findModelInSectionString(content, sectionName string) string {
 	if content == "" {
 		return ""
@@ -645,245 +530,12 @@ func findModelInSectionString(content, sectionName string) string {
 	return ""
 }
 
-// Restore performs surgical restoration: only removes/restores keys and sections
-// that we patched. Non-managed content is untouched.
-func (m *Manager) Restore() error {
-	// Restore the sibling file first — independent of base config.toml.
-	if err := m.restoreSiblingFile(); err != nil {
-		return err
-	}
-
-	// If we never had an original file and we added everything, remove the file.
-	if m.original == nil && allSentinels(m.origRootKeys) && allSentinels(m.origSections) {
-		os.Remove(m.configPath)
-		os.Remove(m.backupPath)
-		return nil
-	}
-
-	data, err := os.ReadFile(m.configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			os.Remove(m.backupPath)
-			return nil
-		}
-		return fmt.Errorf("read config.toml for restore: %w", err)
-	}
-	content := string(data)
-
-	// Restore root keys.
-	for key, orig := range m.origRootKeys {
-		content = m.restoreRootKey(content, key, orig)
-	}
-
-	// Restore sections.
-	for sectionName, orig := range m.origSections {
-		content = m.restoreSection(content, sectionName, orig)
-	}
-
-	// Clean up trailing whitespace.
-	content = strings.TrimRight(content, "\n") + "\n"
-
-	if err := atomicWrite(m.configPath, []byte(content)); err != nil {
-		return fmt.Errorf("restore config.toml: %w", err)
-	}
-	os.Remove(m.backupPath)
-	return nil
-}
-
-// restoreSiblingFile restores the sibling profile-v2 file to its pre-patch
-// state: either rewriting the original contents, or removing the file we
-// created.
-func (m *Manager) restoreSiblingFile() error {
-	if m.siblingExisted {
-		if err := atomicWrite(m.siblingPath, m.siblingOriginal); err != nil {
-			return fmt.Errorf("restore sibling config: %w", err)
-		}
-	} else {
-		if err := os.Remove(m.siblingPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove sibling config: %w", err)
-		}
-	}
-	if err := os.Remove(m.siblingBak); err != nil && !os.IsNotExist(err) {
-		// Backup cleanup failure isn't fatal — log and continue.
-		log.Printf("databricks-codex: failed to remove sibling backup: %v", err)
-	}
-	return nil
-}
-
-// restoreRootKey restores a single root key to its original state.
-func (m *Manager) restoreRootKey(content, key, orig string) string {
-	if orig == sentinel {
-		// Was absent — strip whatever's there now.
-		lines := strings.Split(content, "\n")
-		for i, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if isRootKey(trimmed, key) && !inAnySection(lines, i) {
-				return strings.Join(removeAt(lines, i), "\n")
-			}
-		}
-		return content
-	}
-
-	// Was present pre-patch — put the original line back. Two cases:
-	//   (a) the current content still has the key (e.g. an unrelated edit
-	//       left it intact): replace in place.
-	//   (b) the current content does NOT have the key (we stripped it in
-	//       Patch): re-insert near the top.
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
-			lines[i] = orig
-			return strings.Join(lines, "\n")
-		}
-	}
-	insertIdx := 0
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") {
-			insertIdx = i
-			break
-		}
-		insertIdx = i + 1
-	}
-	lines = insertAt(lines, insertIdx, orig)
-	return strings.Join(lines, "\n")
-}
-
-// restoreSection restores a section to its original state.
-func (m *Manager) restoreSection(content, sectionName, orig string) string {
-	header := "[" + sectionName + "]"
-	lines := strings.Split(content, "\n")
-
-	startIdx := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			startIdx = i
-			break
-		}
-	}
-
-	// Helper: rebuild the lines slice with `replacement` (slice or nil for
-	// pure deletion) replacing [startIdx..endIdx).
-	splice := func(start, end int, replacement []string) string {
-		newLines := make([]string, 0, len(lines)-(end-start)+len(replacement))
-		newLines = append(newLines, lines[:start]...)
-		newLines = append(newLines, replacement...)
-		newLines = append(newLines, lines[end:]...)
-		return strings.Join(newLines, "\n")
-	}
-
-	if startIdx == -1 {
-		// Section is absent from current content. If orig was a sentinel
-		// (it didn't exist pre-patch either), nothing to do. Otherwise we
-		// need to re-add it (we stripped it during Patch). Append at end.
-		if orig == sentinel {
-			return content
-		}
-		// Ensure trailing newline before append.
-		if !strings.HasSuffix(content, "\n") && content != "" {
-			content += "\n"
-		}
-		return content + "\n" + orig + "\n"
-	}
-
-	// Find section end.
-	endIdx := len(lines)
-	for i := startIdx + 1; i < len(lines); i++ {
-		trimmed := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
-			endIdx = i
-			break
-		}
-	}
-
-	if orig == sentinel {
-		// Section was absent — remove the entire block.
-		// Also remove a preceding blank line if present.
-		removeStart := startIdx
-		if removeStart > 0 && strings.TrimSpace(lines[removeStart-1]) == "" {
-			removeStart--
-		}
-		return splice(removeStart, endIdx, nil)
-	}
-
-	// Restore original block.
-	return splice(startIdx, endIdx, strings.Split(orig, "\n"))
-}
-
-// UpdateProxyURL updates only the base_url in the provider section.
-// Used for multi-session handoff when an owner session ends and a survivor
-// rebinds the port: the proxy URL changes, but everything else stays.
-func (m *Manager) UpdateProxyURL(newURL string) error {
-	data, err := os.ReadFile(m.configPath)
-	if err != nil {
-		return fmt.Errorf("read config.toml: %w", err)
-	}
-	content := string(data)
-
-	lines := strings.Split(content, "\n")
-	inSection := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "[model_providers.databricks-proxy]" {
-			inSection = true
-			continue
-		}
-		if inSection {
-			if strings.HasPrefix(trimmed, "[") {
-				break
-			}
-			if strings.HasPrefix(trimmed, "base_url") {
-				lines[i] = fmt.Sprintf("base_url = %q", newURL)
-				break
-			}
-		}
-	}
-
-	return atomicWrite(m.configPath, []byte(strings.Join(lines, "\n")))
-}
-
-// RestoreFromBackup restores config.toml + sibling file from their backup
-// files if backups exist. Returns true if any restore was performed. Used
-// for crash recovery on next startup when a prior session left backups
-// behind without running Restore().
-func (m *Manager) RestoreFromBackup() bool {
-	restored := false
-
-	if data, err := os.ReadFile(m.backupPath); err == nil {
-		if err := atomicWrite(m.configPath, data); err == nil {
-			os.Remove(m.backupPath)
-			restored = true
-		}
-	}
-
-	if data, err := os.ReadFile(m.siblingBak); err == nil {
-		if err := atomicWrite(m.siblingPath, data); err == nil {
-			os.Remove(m.siblingBak)
-			restored = true
-		}
-	} else if os.IsNotExist(err) {
-		// No backup → sibling file is ours from this aborted session;
-		// remove it if present so it doesn't linger.
-		if _, statErr := os.Stat(m.siblingPath); statErr == nil {
-			if rerr := os.Remove(m.siblingPath); rerr == nil {
-				restored = true
-			}
-		}
-	}
-
-	return restored
-}
-
-// --- Helpers ---
-
 // isRootKey checks if a trimmed line is a root-level assignment for the given key.
 func isRootKey(trimmed, key string) bool {
 	return strings.HasPrefix(trimmed, key+" ") || strings.HasPrefix(trimmed, key+"=")
 }
 
-// inAnySection returns true if line at idx is inside a [section] (i.e., there's
-// a section header somewhere above it with no intervening root-level context).
+// inAnySection returns true if line at idx is inside a [section].
 func inAnySection(lines []string, idx int) bool {
 	for i := idx - 1; i >= 0; i-- {
 		trimmed := strings.TrimSpace(lines[i])
@@ -892,16 +544,6 @@ func inAnySection(lines []string, idx int) bool {
 		}
 	}
 	return false
-}
-
-// allSentinels returns true if all values in the map are sentinel.
-func allSentinels(m map[string]string) bool {
-	for _, v := range m {
-		if v != sentinel {
-			return false
-		}
-	}
-	return true
 }
 
 // insertAt inserts a string at the given index in a slice.
@@ -936,7 +578,6 @@ func atomicWrite(path string, data []byte) error {
 		os.Remove(tmpPath)
 		return err
 	}
-
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)

--- a/pkg/tomlconfig/tomlconfig.go
+++ b/pkg/tomlconfig/tomlconfig.go
@@ -148,6 +148,29 @@ var managedSections = []string{
 	"otel",
 }
 
+// managedRootKeys lists root-level keys we own in base config.toml.
+//
+// Why root keys, even though profile-v2 gives us a sibling layer:
+//
+//   - The Codex GUI (and certain IDE extensions / raw `codex` invocations
+//     that don't pass --profile) ignore profile-v2 layering and read the
+//     root-level `model_provider` directly. Without these root keys, the
+//     GUI falls through to the built-in `openai` provider (which has
+//     supports_websockets = true hardcoded), attempts a WebSocket
+//     upgrade against Databricks AI Gateway, and gets HTTP 400.
+//     Confirmed by upstream issue openai/codex#13041 — the recommended
+//     workaround is exactly this root-level provider override.
+//
+//   - The transparent-wrapper path (`databricks-codex "..."`) still uses
+//     --profile databricks-proxy + the sibling file. Both paths converge
+//     on the same provider, because the sibling overrides root with the
+//     same values.
+//
+// We do NOT write a root `profile = "..."` key — Codex profile-v2 rejects
+// that (codex-rs/core/src/config/mod.rs:2606) and stripping it on Patch
+// is the migration path for users upgrading from pre-v0.7.
+var managedRootKeys = []string{"model_provider", "model"}
+
 // Patch performs surgical patching of config.toml: it reads the existing file,
 // saves originals for keys/sections it will touch, then injects/updates only
 // managed keys and sections. All non-managed content is preserved byte-for-byte.
@@ -180,6 +203,18 @@ func (m *Manager) Patch(cfg PatchConfig) error {
 		content = m.stripRootKey(content, "profile")
 	}
 	content = m.stripSection(content, "profiles.databricks-proxy")
+
+	// --- Root-level provider override (fixes GUI / raw codex paths) ---
+	//
+	// See managedRootKeys doc above. Root model_provider points at our
+	// proxy provider; root model is the resolved value (same as what we
+	// put in the sibling file). On Restore, the user's original root
+	// model/model_provider come back via origRootKeys.
+	content = m.patchRootKey(content, "model_provider", fmt.Sprintf("%q", SiblingProfileName))
+	rootModel := m.resolveSiblingModel(cfg, rootProfileVal)
+	if rootModel != "" {
+		content = m.patchRootKey(content, "model", fmt.Sprintf("%q", rootModel))
+	}
 
 	// --- Sections we still own in base config.toml ---
 	content = m.patchSection(content, "model_providers.databricks-proxy",
@@ -274,12 +309,27 @@ func (m *Manager) resolveSiblingModel(cfg PatchConfig, legacyRootProfile string)
 }
 
 // buildProviderSection builds the [model_providers.databricks-proxy] section body.
+//
+// supports_websockets = false is written explicitly (defensive — the serde
+// default is also false). Codex's model client prefers WebSocket transport
+// for the Responses API whenever the provider has supports_websockets =
+// true, falling back to SSE-over-HTTP only on connection failure
+// (codex-rs/core/src/client.rs:1601-1640 — stream_responses_websocket
+// then try_switch_fallback_transport). Databricks AI Gateway speaks SSE
+// over POST /v1/responses but does NOT accept WebSocket upgrades, so we
+// must keep this field off — if a stale config has it set to true, the
+// Codex GUI will WebSocket-upgrade and receive 400s from upstream until
+// the per-session fallback kicks in.
+//
+// See client.rs:798 (responses_websocket_enabled gate) and
+// model-provider-info/src/lib.rs:134-136 (the field itself).
 func (m *Manager) buildProviderSection(cfg PatchConfig) string {
 	var b strings.Builder
 	b.WriteString("name = \"Databricks Proxy\"\n")
 	b.WriteString(fmt.Sprintf("base_url = %q\n", cfg.ProxyURL))
 	b.WriteString("api_key = \"databricks-proxy\"\n")
 	b.WriteString("wire_api = \"responses\"\n")
+	b.WriteString("supports_websockets = false\n")
 	return b.String()
 }
 
@@ -316,6 +366,46 @@ func (m *Manager) stripRootKey(content, key string) string {
 		}
 	}
 	return content
+}
+
+// patchRootKey writes (or overwrites) a root-level key to the given value,
+// recording the original for Restore. If the key was absent, sentinel is
+// recorded so Restore removes the line entirely. If it was present, the
+// original line is preserved verbatim so Restore can put it back exactly.
+//
+// value is the right-hand side of the assignment — callers are responsible
+// for quoting (e.g. fmt.Sprintf("%q", "foo")).
+func (m *Manager) patchRootKey(content, key, value string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
+			// Only record the FIRST patch's original — subsequent
+			// patches in the same session are overwriting our own
+			// previous write, not user content. If origRootKeys
+			// already has an entry we keep it.
+			if _, seen := m.origRootKeys[key]; !seen {
+				m.origRootKeys[key] = line
+			}
+			lines[i] = fmt.Sprintf("%s = %s", key, value)
+			return strings.Join(lines, "\n")
+		}
+	}
+	// Key absent — record sentinel, prepend at top (above first section).
+	if _, seen := m.origRootKeys[key]; !seen {
+		m.origRootKeys[key] = sentinel
+	}
+	insertIdx := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			insertIdx = i
+			break
+		}
+		insertIdx = i + 1
+	}
+	lines = insertAt(lines, insertIdx, fmt.Sprintf("%s = %s", key, value))
+	return strings.Join(lines, "\n")
 }
 
 // stripSection removes a [section] from content if present, recording the

--- a/pkg/tomlconfig/tomlconfig_test.go
+++ b/pkg/tomlconfig/tomlconfig_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 )
 
-func setup(t *testing.T, initialContent string) (*Manager, string) {
+// writeConfig seeds ~/.codex/config.toml with the given content and
+// returns a Manager pointed at it. No Backup() call — there is no
+// Backup in the write-once model.
+func writeConfig(t *testing.T, initialContent string) (*Manager, string) {
 	t.Helper()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
@@ -16,11 +19,7 @@ func setup(t *testing.T, initialContent string) (*Manager, string) {
 			t.Fatal(err)
 		}
 	}
-	m := NewManager(configPath)
-	if err := m.Backup(); err != nil {
-		t.Fatal(err)
-	}
-	return m, configPath
+	return NewManager(configPath), configPath
 }
 
 func readConfig(t *testing.T, path string) string {
@@ -32,7 +31,6 @@ func readConfig(t *testing.T, path string) string {
 	return string(data)
 }
 
-// readSibling returns the contents of the profile-v2 sibling file.
 func readSibling(t *testing.T, m *Manager) string {
 	t.Helper()
 	data, err := os.ReadFile(m.SiblingPath())
@@ -42,33 +40,31 @@ func readSibling(t *testing.T, m *Manager) string {
 	return string(data)
 }
 
-// TestPatch_WritesV2Layout verifies that an empty starting config produces
-// the expected profile-v2 layout: provider section in base, profile fields
-// in sibling, NO legacy `profile = ...` root key or `[profiles.X]` table.
+// TestPatch_WritesV2Layout verifies that an empty starting config
+// produces the expected profile-v2 layout: provider section in base,
+// root model_provider+model override, sibling file, supports_websockets
+// off, no legacy keys.
 func TestPatch_WritesV2Layout(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.toml")
-	m := NewManager(configPath)
-	if err := m.Backup(); err != nil {
-		t.Fatal(err)
-	}
+	m, configPath := writeConfig(t, "")
 
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Base config: provider section present, NO legacy layout.
 	content := readConfig(t, configPath)
+
+	// Provider section + base_url.
 	if !strings.Contains(content, "[model_providers.databricks-proxy]") {
 		t.Errorf("expected provider section in base, got:\n%s", content)
 	}
 	if !strings.Contains(content, `base_url = "http://127.0.0.1:9999"`) {
 		t.Errorf("expected base_url in provider section, got:\n%s", content)
 	}
+
+	// NO legacy v1 layout.
 	if strings.Contains(content, `profile = "databricks-proxy"`) {
 		t.Errorf("v2: base config must NOT contain legacy root profile key, got:\n%s", content)
 	}
@@ -76,7 +72,7 @@ func TestPatch_WritesV2Layout(t *testing.T) {
 		t.Errorf("v2: base config must NOT contain legacy [profiles.databricks-proxy] table, got:\n%s", content)
 	}
 
-	// Sibling file: profile-v2 layer with model_provider + model.
+	// Sibling file with profile-v2 layer.
 	sibling := readSibling(t, m)
 	if !strings.Contains(sibling, `model_provider = "databricks-proxy"`) {
 		t.Errorf("expected model_provider in sibling, got:\n%s", sibling)
@@ -85,16 +81,13 @@ func TestPatch_WritesV2Layout(t *testing.T) {
 		t.Errorf("expected model in sibling, got:\n%s", sibling)
 	}
 
-	// Provider must opt OUT of WebSocket transport — Databricks AI
-	// Gateway is SSE-only over /v1/responses, no WebSocket upgrade.
-	// See buildProviderSection doc comment for the upstream code refs.
+	// supports_websockets opt-out (Databricks AI Gateway is SSE-only).
 	if !strings.Contains(content, "supports_websockets = false") {
-		t.Errorf("provider section must set supports_websockets = false (Databricks AI Gateway has no WebSocket transport), got:\n%s", content)
+		t.Errorf("provider section must set supports_websockets = false, got:\n%s", content)
 	}
 
-	// Root-level model_provider + model must point at our proxy so that
-	// the Codex GUI and raw `codex` invocations (which ignore profile-v2
-	// layering — confirmed by openai/codex#13041) route through us.
+	// Root-level model_provider + model — the GUI/raw-codex fix
+	// (openai/codex#13041).
 	if !strings.Contains(content, `model_provider = "databricks-proxy"`) {
 		t.Errorf("expected root-level model_provider override in base config, got:\n%s", content)
 	}
@@ -113,13 +106,12 @@ sandbox_permissions = "full-auto"
 model_provider = "openai"
 model = "gpt-4"
 `
-	m, configPath := setup(t, initial)
+	m, configPath := writeConfig(t, initial)
 
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,25 +120,49 @@ model = "gpt-4"
 	if !strings.Contains(content, `profile = "myprofile"`) {
 		t.Errorf("expected user's root profile to be preserved, got:\n%s", content)
 	}
-	// User's project section must survive.
 	if !strings.Contains(content, "[projects.myapp]") {
 		t.Error("expected [projects.myapp] to be preserved")
 	}
 	if !strings.Contains(content, `sandbox_permissions = "full-auto"`) {
 		t.Error("expected sandbox_permissions to be preserved")
 	}
-	// User's other profile must survive.
 	if !strings.Contains(content, "[profiles.myprofile]") {
 		t.Error("expected [profiles.myprofile] to be preserved")
+	}
+}
+
+// TestPatch_OverwritesUserRootModelProvider documents the write-once
+// trade-off: we DO clobber a user's root model_provider/model with our
+// own values (otherwise the GUI/raw-codex fix wouldn't take effect).
+// This is intentional — Restore is not part of the model — but the test
+// pins the behavior so the contract is explicit.
+func TestPatch_OverwritesUserRootModelProvider(t *testing.T) {
+	initial := `model_provider = "openai"
+model = "gpt-5"
+`
+	m, configPath := writeConfig(t, initial)
+
+	if err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model_provider = "databricks-proxy"`) {
+		t.Errorf("expected our model_provider to win, got:\n%s", content)
+	}
+	if strings.Contains(content, `model_provider = "openai"`) {
+		t.Errorf("expected user's openai model_provider to be overwritten, got:\n%s", content)
 	}
 }
 
 // TestPatch_MigratesLegacyDatabricksProxyKeys covers the upgrade path: a
 // user previously ran an old databricks-codex that left
 // `profile = "databricks-proxy"` + `[profiles.databricks-proxy]` in base
-// config.toml. The new Patch must strip those (so Codex profile-v2 doesn't
-// reject the config) AND carry the model value forward into the sibling
-// file.
+// config.toml. The new Patch strips both (so Codex profile-v2 accepts
+// the config) AND carries the model value forward into the sibling.
 func TestPatch_MigratesLegacyDatabricksProxyKeys(t *testing.T) {
 	initial := `profile = "databricks-proxy"
 
@@ -163,14 +179,13 @@ wire_api = "responses"
 [projects.myapp]
 trust_level = "trusted"
 `
-	m, configPath := setup(t, initial)
+	m, configPath := writeConfig(t, initial)
 
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-5",
 		ModelExplicit: false,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -185,38 +200,10 @@ trust_level = "trusted"
 		t.Errorf("unrelated user section must survive migration, got:\n%s", content)
 	}
 
-	// Sibling: carries forward the legacy model value.
+	// Sibling: carries forward the legacy model value (preserve-if-present).
 	sibling := readSibling(t, m)
 	if !strings.Contains(sibling, `model = "custom-user-model"`) {
 		t.Errorf("expected legacy model to be migrated into sibling file, got:\n%s", sibling)
-	}
-}
-
-func TestPatch_PreservesUserModel(t *testing.T) {
-	// Same flow as TestPatch_MigratesLegacyDatabricksProxyKeys but
-	// asserts the preserve-if-present semantics from the user's angle: a
-	// custom model in the legacy section migrates into the sibling
-	// without being overwritten by the resolved fallback.
-	initial := `profile = "databricks-proxy"
-
-[profiles.databricks-proxy]
-model_provider = "databricks-proxy"
-model = "custom-user-model"
-`
-	m, _ := setup(t, initial)
-
-	err := m.Patch(PatchConfig{
-		ProxyURL:      "http://127.0.0.1:9999",
-		Model:         "databricks-gpt-5-5",
-		ModelExplicit: false,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sibling := readSibling(t, m)
-	if !strings.Contains(sibling, `model = "custom-user-model"`) {
-		t.Errorf("expected user model to be preserved in sibling, got:\n%s", sibling)
 	}
 }
 
@@ -227,14 +214,13 @@ func TestPatch_OverridesModelWhenExplicit(t *testing.T) {
 model_provider = "databricks-proxy"
 model = "custom-user-model"
 `
-	m, _ := setup(t, initial)
+	m, _ := writeConfig(t, initial)
 
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-4-mini",
 		ModelExplicit: true,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -247,15 +233,14 @@ model = "custom-user-model"
 	}
 }
 
-// TestPatch_PreservesExistingSiblingModel verifies that if a sibling file
-// already exists (user edited it, or a prior session wrote it), its model
-// value is preserved when ModelExplicit=false.
+// TestPatch_PreservesExistingSiblingModel: if a sibling file already
+// exists, its model value wins over the resolved fallback (ModelExplicit
+// = false).
 func TestPatch_PreservesExistingSiblingModel(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
 
-	// Seed sibling with a user-set model.
 	if err := os.WriteFile(siblingPath, []byte(`model_provider = "databricks-proxy"
 model = "user-picked-model"
 `), 0o600); err != nil {
@@ -263,16 +248,11 @@ model = "user-picked-model"
 	}
 
 	m := NewManager(configPath)
-	if err := m.Backup(); err != nil {
-		t.Fatal(err)
-	}
-
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-5",
 		ModelExplicit: false,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -282,229 +262,19 @@ model = "user-picked-model"
 	}
 }
 
-func TestRestore_RemovesAddedSections(t *testing.T) {
-	// Start with a config that has NO databricks-proxy sections AND no
-	// sibling file. Restore must remove everything we added.
-	initial := `[projects.myapp]
-sandbox_permissions = "full-auto"
-`
-	m, configPath := setup(t, initial)
-
-	err := m.Patch(PatchConfig{
-		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify patch added the provider section + sibling file.
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, "[model_providers.databricks-proxy]") {
-		t.Fatal("patch should have added provider section")
-	}
-	if _, err := os.Stat(m.SiblingPath()); err != nil {
-		t.Fatalf("patch should have created sibling file: %v", err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	content = readConfig(t, configPath)
-	if strings.Contains(content, "[model_providers.databricks-proxy]") {
-		t.Error("expected [model_providers.databricks-proxy] to be removed after restore")
-	}
-	// User section must survive.
-	if !strings.Contains(content, "[projects.myapp]") {
-		t.Error("expected [projects.myapp] to survive restore")
-	}
-	// Sibling file must be gone (it didn't exist pre-patch).
-	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
-		t.Error("expected sibling file to be removed after restore")
-	}
-}
-
-// TestRestore_PutsBackLegacyKeys verifies that when Patch strips legacy
-// `profile = "databricks-proxy"` and `[profiles.databricks-proxy]` from
-// base config, Restore puts them back. Symmetric round-trip — important
-// when a pre-v0.7 databricks-codex left state behind and the user is just
-// running a single session of the new wrapper.
-func TestRestore_PutsBackLegacyKeys(t *testing.T) {
-	initial := `profile = "databricks-proxy"
-
-[profiles.databricks-proxy]
-model_provider = "databricks-proxy"
-model = "original-model"
-
-[model_providers.databricks-proxy]
-name = "Databricks Proxy"
-base_url = "http://old-proxy:1234"
-api_key = "databricks-proxy"
-wire_api = "responses"
-
-[projects.myapp]
-sandbox_permissions = "full-auto"
-`
-	m, configPath := setup(t, initial)
-
-	err := m.Patch(PatchConfig{
-		ProxyURL:      "http://127.0.0.1:9999",
-		Model:         "new-model",
-		ModelExplicit: true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `profile = "databricks-proxy"`) {
-		t.Errorf("expected legacy root profile to be restored, got:\n%s", content)
-	}
-	if !strings.Contains(content, "[profiles.databricks-proxy]") {
-		t.Errorf("expected legacy [profiles.databricks-proxy] to be restored, got:\n%s", content)
-	}
-	if !strings.Contains(content, `model = "original-model"`) {
-		t.Errorf("expected original model to be restored inside legacy section, got:\n%s", content)
-	}
-	if !strings.Contains(content, "[projects.myapp]") {
-		t.Errorf("expected user section preserved, got:\n%s", content)
-	}
-	// Sibling file must be gone (it didn't exist pre-patch).
-	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
-		t.Error("expected sibling file to be removed after restore")
-	}
-}
-
-func TestRestore_PreservesUnmanagedContent(t *testing.T) {
-	initial := `custom_key = "custom_value"
-
-[projects.myapp]
-sandbox_permissions = "full-auto"
-
-[notice]
-shown = true
-`
-	m, configPath := setup(t, initial)
-
-	err := m.Patch(PatchConfig{
-		ProxyURL:         "http://127.0.0.1:9999",
-		Model:            "databricks-gpt-5-5",
-		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `custom_key = "custom_value"`) {
-		t.Errorf("expected custom_key to survive, got:\n%s", content)
-	}
-	if !strings.Contains(content, "[projects.myapp]") {
-		t.Errorf("expected [projects.myapp] to survive, got:\n%s", content)
-	}
-	if !strings.Contains(content, "[notice]") {
-		t.Errorf("expected [notice] to survive, got:\n%s", content)
-	}
-	// OTEL section should be removed (it was absent before).
-	if strings.Contains(content, "[otel]") {
-		t.Errorf("expected [otel] to be removed after restore, got:\n%s", content)
-	}
-}
-
-// TestRestore_PreservesExistingSibling verifies that if a sibling file
-// existed pre-patch (e.g. user maintains one), Restore puts its original
-// content back byte-for-byte, not just deletes it.
-func TestRestore_PreservesExistingSibling(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.toml")
-	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
-	originalSibling := `model_provider = "databricks-proxy"
-model = "user-handcrafted"
-# user comment
-`
-	if err := os.WriteFile(siblingPath, []byte(originalSibling), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	m := NewManager(configPath)
-	if err := m.Backup(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Patch(PatchConfig{
-		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-5",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(siblingPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != originalSibling {
-		t.Errorf("sibling restore did not preserve content byte-for-byte\nwant:\n%s\ngot:\n%s", originalSibling, string(got))
-	}
-}
-
-func TestRestore_NoOriginalFile(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.toml")
-	m := NewManager(configPath)
-	if err := m.Backup(); err != nil {
-		t.Fatal(err)
-	}
-
-	err := m.Patch(PatchConfig{
-		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	// File should be removed since it didn't exist before.
-	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
-		t.Error("expected config.toml to be removed after restore when it didn't exist before")
-	}
-	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
-		t.Error("expected sibling file to be removed after restore when it didn't exist before")
-	}
-}
-
 func TestPatch_RespectsRootLevelModel(t *testing.T) {
 	initial := `model = "databricks-gpt-5-3"
 
 [projects."/Users/me/myproject"]
 trust_level = "trusted"
 `
-	m, _ := setup(t, initial)
+	m, _ := writeConfig(t, initial)
 
-	// No --model flag (ModelExplicit=false), no model in sibling.
-	// Should pick up the root-level model and write it into sibling.
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-5",
 		ModelExplicit: false,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -512,25 +282,18 @@ trust_level = "trusted"
 	if !strings.Contains(sibling, `model = "databricks-gpt-5-3"`) {
 		t.Errorf("expected root-level model to be carried into sibling, got:\n%s", sibling)
 	}
-	if strings.Contains(sibling, `model = "databricks-gpt-5-5"`) {
-		t.Errorf("expected fallback model NOT to be used when root-level model exists, got:\n%s", sibling)
-	}
 }
 
 func TestPatch_RootLevelModelOverriddenByExplicitFlag(t *testing.T) {
 	initial := `model = "databricks-gpt-5-3"
-
-[projects."/Users/me/myproject"]
-trust_level = "trusted"
 `
-	m, _ := setup(t, initial)
+	m, _ := writeConfig(t, initial)
 
-	err := m.Patch(PatchConfig{
+	if err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-4-mini",
 		ModelExplicit: true,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -541,17 +304,14 @@ trust_level = "trusted"
 }
 
 func TestPatch_WithOTEL(t *testing.T) {
-	m, configPath := setup(t, "")
-
-	err := m.Patch(PatchConfig{
+	m, configPath := writeConfig(t, "")
+	if err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
 		Model:            "databricks-gpt-5-5",
 		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
 	if !strings.Contains(content, "[otel]") {
 		t.Error("expected [otel] section")
@@ -562,23 +322,17 @@ func TestPatch_WithOTEL(t *testing.T) {
 }
 
 func TestPatch_WithOTELMetricsOnly(t *testing.T) {
-	m, configPath := setup(t, "")
-
-	err := m.Patch(PatchConfig{
+	m, configPath := writeConfig(t, "")
+	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
-	if !strings.Contains(content, "[otel]") {
-		t.Error("expected [otel] section")
-	}
 	if !strings.Contains(content, `metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
-		t.Errorf("expected metrics_exporter key in [otel] section, got:\n%s", content)
+		t.Errorf("expected metrics_exporter key, got:\n%s", content)
 	}
 	if strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
 		t.Errorf("expected no logs exporter when only metrics endpoint provided, got:\n%s", content)
@@ -586,38 +340,32 @@ func TestPatch_WithOTELMetricsOnly(t *testing.T) {
 }
 
 func TestPatch_WithBothOTELExporters(t *testing.T) {
-	m, configPath := setup(t, "")
-
-	err := m.Patch(PatchConfig{
+	m, configPath := writeConfig(t, "")
+	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
 		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
 		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
 	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
-		t.Errorf("expected logs endpoint in [otel] section, got:\n%s", content)
+		t.Errorf("expected logs endpoint, got:\n%s", content)
 	}
 	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
-		t.Errorf("expected metrics endpoint in [otel] section, got:\n%s", content)
+		t.Errorf("expected metrics endpoint, got:\n%s", content)
 	}
 }
 
 func TestPatch_NoOTELSectionWhenBothEmpty(t *testing.T) {
-	m, configPath := setup(t, "")
-
-	err := m.Patch(PatchConfig{
+	m, configPath := writeConfig(t, "")
+	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
 	if strings.Contains(content, "[otel]") {
 		t.Errorf("expected no [otel] section when both endpoints empty, got:\n%s", content)
@@ -625,8 +373,7 @@ func TestPatch_NoOTELSectionWhenBothEmpty(t *testing.T) {
 }
 
 func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
-	m, configPath := setup(t, "")
-
+	m, configPath := writeConfig(t, "")
 	if err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
 		Model:            "databricks-gpt-5-5",
@@ -634,7 +381,6 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
@@ -643,7 +389,6 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
 	if !strings.Contains(content, `metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
 		t.Errorf("expected metrics_exporter after re-patch, got:\n%s", content)
@@ -654,8 +399,7 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 }
 
 func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
-	m, configPath := setup(t, "")
-
+	m, configPath := writeConfig(t, "")
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
@@ -664,19 +408,16 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 	before := readConfig(t, configPath)
 	if !strings.Contains(before, "[otel]") {
 		t.Fatalf("setup error: expected [otel] section after first patch, got:\n%s", before)
 	}
-
 	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 	after := readConfig(t, configPath)
 	if strings.Contains(after, "[otel]") {
 		t.Errorf("expected [otel] section to be removed after empty-endpoints patch, got:\n%s", after)
@@ -684,164 +425,24 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	if strings.Contains(after, "exporter = { otlp-http") {
 		t.Errorf("expected no stale exporter line after removal, got:\n%s", after)
 	}
-	if strings.Contains(after, "metrics_exporter") {
-		t.Errorf("expected no stale metrics_exporter line after removal, got:\n%s", after)
-	}
-	// Provider section should survive.
 	if !strings.Contains(after, "[model_providers.databricks-proxy]") {
-		t.Errorf("expected [model_providers.databricks-proxy] to survive [otel] removal, got:\n%s", after)
+		t.Errorf("expected provider section to survive [otel] removal, got:\n%s", after)
 	}
 }
 
 func TestUpdateProxyURL(t *testing.T) {
-	m, configPath := setup(t, "")
-
-	err := m.Patch(PatchConfig{
+	m, configPath := writeConfig(t, "")
+	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := m.UpdateProxyURL("http://127.0.0.1:8888"); err != nil {
 		t.Fatal(err)
 	}
-
 	content := readConfig(t, configPath)
 	if !strings.Contains(content, `base_url = "http://127.0.0.1:8888"`) {
 		t.Errorf("expected updated base_url, got:\n%s", content)
-	}
-}
-
-func TestRestoreFromBackup(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.toml")
-	backupPath := configPath + ".databricks-codex-backup"
-
-	original := `profile = "myprofile"
-`
-	if err := os.WriteFile(backupPath, []byte(original), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(configPath, []byte(`profile = "databricks-proxy"`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	m := NewManager(configPath)
-	restored := m.RestoreFromBackup()
-	if !restored {
-		t.Error("expected RestoreFromBackup to return true")
-	}
-
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `profile = "myprofile"`) {
-		t.Errorf("expected original content restored from backup, got:\n%s", content)
-	}
-
-	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
-		t.Error("expected backup file to be removed after restore")
-	}
-}
-
-// TestRestore_PutsBackUserRootModelProvider verifies that a user's
-// pre-existing root `model_provider` and `model` keys are restored after
-// our session ends — the GUI/raw-codex fix overwrites them at session
-// start, so Restore must put them back.
-func TestRestore_PutsBackUserRootModelProvider(t *testing.T) {
-	initial := `model_provider = "openai"
-model = "gpt-5"
-
-[projects.myapp]
-trust_level = "trusted"
-`
-	m, configPath := setup(t, initial)
-
-	if err := m.Patch(PatchConfig{
-		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-5",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// During the session: our values are active.
-	mid := readConfig(t, configPath)
-	if !strings.Contains(mid, `model_provider = "databricks-proxy"`) {
-		t.Fatalf("expected our model_provider mid-session, got:\n%s", mid)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `model_provider = "openai"`) {
-		t.Errorf("expected user's model_provider to be restored, got:\n%s", content)
-	}
-	if !strings.Contains(content, `model = "gpt-5"`) {
-		t.Errorf("expected user's model to be restored, got:\n%s", content)
-	}
-	if !strings.Contains(content, "[projects.myapp]") {
-		t.Errorf("expected user section to survive, got:\n%s", content)
-	}
-}
-
-// TestRestore_RemovesAddedRootKeys verifies that root keys we added (no
-// originals) are fully removed on Restore.
-func TestRestore_RemovesAddedRootKeys(t *testing.T) {
-	initial := `[projects.myapp]
-trust_level = "trusted"
-`
-	m, configPath := setup(t, initial)
-
-	if err := m.Patch(PatchConfig{
-		ProxyURL: "http://127.0.0.1:9999",
-		Model:    "databricks-gpt-5-5",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.Restore(); err != nil {
-		t.Fatal(err)
-	}
-
-	content := readConfig(t, configPath)
-	if strings.Contains(content, "model_provider") {
-		t.Errorf("expected model_provider to be removed (was absent pre-patch), got:\n%s", content)
-	}
-	if strings.Contains(content, "model = ") {
-		t.Errorf("expected model to be removed (was absent pre-patch), got:\n%s", content)
-	}
-}
-
-// TestRestoreFromBackup_RemovesOrphanSibling verifies that crash recovery
-// also removes a sibling file that the crashed session wrote (no backup
-// means the sibling wasn't there before).
-func TestRestoreFromBackup_RemovesOrphanSibling(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "config.toml")
-	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
-	backupPath := configPath + ".databricks-codex-backup"
-
-	// Crashed session left: original backed up, sibling written, no sibling backup.
-	if err := os.WriteFile(backupPath, []byte(`# original
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(configPath, []byte(`# patched
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(siblingPath, []byte(`model_provider = "databricks-proxy"
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	m := NewManager(configPath)
-	if !m.RestoreFromBackup() {
-		t.Error("expected RestoreFromBackup to return true")
-	}
-	if _, err := os.Stat(siblingPath); !os.IsNotExist(err) {
-		t.Error("expected orphan sibling file to be removed during crash recovery")
 	}
 }

--- a/pkg/tomlconfig/tomlconfig_test.go
+++ b/pkg/tomlconfig/tomlconfig_test.go
@@ -84,6 +84,23 @@ func TestPatch_WritesV2Layout(t *testing.T) {
 	if !strings.Contains(sibling, `model = "databricks-gpt-5-5"`) {
 		t.Errorf("expected model in sibling, got:\n%s", sibling)
 	}
+
+	// Provider must opt OUT of WebSocket transport — Databricks AI
+	// Gateway is SSE-only over /v1/responses, no WebSocket upgrade.
+	// See buildProviderSection doc comment for the upstream code refs.
+	if !strings.Contains(content, "supports_websockets = false") {
+		t.Errorf("provider section must set supports_websockets = false (Databricks AI Gateway has no WebSocket transport), got:\n%s", content)
+	}
+
+	// Root-level model_provider + model must point at our proxy so that
+	// the Codex GUI and raw `codex` invocations (which ignore profile-v2
+	// layering — confirmed by openai/codex#13041) route through us.
+	if !strings.Contains(content, `model_provider = "databricks-proxy"`) {
+		t.Errorf("expected root-level model_provider override in base config, got:\n%s", content)
+	}
+	if !strings.Contains(content, `model = "databricks-gpt-5-5"`) {
+		t.Errorf("expected root-level model in base config, got:\n%s", content)
+	}
 }
 
 func TestPatch_PreservesUserSections(t *testing.T) {
@@ -724,6 +741,76 @@ func TestRestoreFromBackup(t *testing.T) {
 
 	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
 		t.Error("expected backup file to be removed after restore")
+	}
+}
+
+// TestRestore_PutsBackUserRootModelProvider verifies that a user's
+// pre-existing root `model_provider` and `model` keys are restored after
+// our session ends — the GUI/raw-codex fix overwrites them at session
+// start, so Restore must put them back.
+func TestRestore_PutsBackUserRootModelProvider(t *testing.T) {
+	initial := `model_provider = "openai"
+model = "gpt-5"
+
+[projects.myapp]
+trust_level = "trusted"
+`
+	m, configPath := setup(t, initial)
+
+	if err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// During the session: our values are active.
+	mid := readConfig(t, configPath)
+	if !strings.Contains(mid, `model_provider = "databricks-proxy"`) {
+		t.Fatalf("expected our model_provider mid-session, got:\n%s", mid)
+	}
+
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model_provider = "openai"`) {
+		t.Errorf("expected user's model_provider to be restored, got:\n%s", content)
+	}
+	if !strings.Contains(content, `model = "gpt-5"`) {
+		t.Errorf("expected user's model to be restored, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Errorf("expected user section to survive, got:\n%s", content)
+	}
+}
+
+// TestRestore_RemovesAddedRootKeys verifies that root keys we added (no
+// originals) are fully removed on Restore.
+func TestRestore_RemovesAddedRootKeys(t *testing.T) {
+	initial := `[projects.myapp]
+trust_level = "trusted"
+`
+	m, configPath := setup(t, initial)
+
+	if err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if strings.Contains(content, "model_provider") {
+		t.Errorf("expected model_provider to be removed (was absent pre-patch), got:\n%s", content)
+	}
+	if strings.Contains(content, "model = ") {
+		t.Errorf("expected model to be removed (was absent pre-patch), got:\n%s", content)
 	}
 }
 

--- a/pkg/tomlconfig/tomlconfig_test.go
+++ b/pkg/tomlconfig/tomlconfig_test.go
@@ -32,7 +32,20 @@ func readConfig(t *testing.T, path string) string {
 	return string(data)
 }
 
-func TestPatch_EmptyConfig(t *testing.T) {
+// readSibling returns the contents of the profile-v2 sibling file.
+func readSibling(t *testing.T, m *Manager) string {
+	t.Helper()
+	data, err := os.ReadFile(m.SiblingPath())
+	if err != nil {
+		t.Fatalf("read sibling file: %v", err)
+	}
+	return string(data)
+}
+
+// TestPatch_WritesV2Layout verifies that an empty starting config produces
+// the expected profile-v2 layout: provider section in base, profile fields
+// in sibling, NO legacy `profile = ...` root key or `[profiles.X]` table.
+func TestPatch_WritesV2Layout(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 	m := NewManager(configPath)
@@ -48,18 +61,28 @@ func TestPatch_EmptyConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Base config: provider section present, NO legacy layout.
 	content := readConfig(t, configPath)
-	if !strings.Contains(content, `profile = "databricks-proxy"`) {
-		t.Error("expected profile root key")
-	}
-	if !strings.Contains(content, "[profiles.databricks-proxy]") {
-		t.Error("expected profiles section")
-	}
-	if !strings.Contains(content, `model = "databricks-gpt-5-5"`) {
-		t.Error("expected model in profile section")
+	if !strings.Contains(content, "[model_providers.databricks-proxy]") {
+		t.Errorf("expected provider section in base, got:\n%s", content)
 	}
 	if !strings.Contains(content, `base_url = "http://127.0.0.1:9999"`) {
-		t.Error("expected base_url in provider section")
+		t.Errorf("expected base_url in provider section, got:\n%s", content)
+	}
+	if strings.Contains(content, `profile = "databricks-proxy"`) {
+		t.Errorf("v2: base config must NOT contain legacy root profile key, got:\n%s", content)
+	}
+	if strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Errorf("v2: base config must NOT contain legacy [profiles.databricks-proxy] table, got:\n%s", content)
+	}
+
+	// Sibling file: profile-v2 layer with model_provider + model.
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model_provider = "databricks-proxy"`) {
+		t.Errorf("expected model_provider in sibling, got:\n%s", sibling)
+	}
+	if !strings.Contains(sibling, `model = "databricks-gpt-5-5"`) {
+		t.Errorf("expected model in sibling, got:\n%s", sibling)
 	}
 }
 
@@ -84,7 +107,11 @@ model = "gpt-4"
 	}
 
 	content := readConfig(t, configPath)
-	// User section must survive.
+	// User's profile root key (NOT databricks-proxy) must survive.
+	if !strings.Contains(content, `profile = "myprofile"`) {
+		t.Errorf("expected user's root profile to be preserved, got:\n%s", content)
+	}
+	// User's project section must survive.
 	if !strings.Contains(content, "[projects.myapp]") {
 		t.Error("expected [projects.myapp] to be preserved")
 	}
@@ -97,7 +124,13 @@ model = "gpt-4"
 	}
 }
 
-func TestPatch_PreservesUserModel(t *testing.T) {
+// TestPatch_MigratesLegacyDatabricksProxyKeys covers the upgrade path: a
+// user previously ran an old databricks-codex that left
+// `profile = "databricks-proxy"` + `[profiles.databricks-proxy]` in base
+// config.toml. The new Patch must strip those (so Codex profile-v2 doesn't
+// reject the config) AND carry the model value forward into the sibling
+// file.
+func TestPatch_MigratesLegacyDatabricksProxyKeys(t *testing.T) {
 	initial := `profile = "databricks-proxy"
 
 [profiles.databricks-proxy]
@@ -109,10 +142,12 @@ name = "Databricks Proxy"
 base_url = "http://old-proxy:1234"
 api_key = "databricks-proxy"
 wire_api = "responses"
+
+[projects.myapp]
+trust_level = "trusted"
 `
 	m, configPath := setup(t, initial)
 
-	// ModelExplicit=false: should preserve user's model.
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-5",
@@ -123,8 +158,48 @@ wire_api = "responses"
 	}
 
 	content := readConfig(t, configPath)
-	if !strings.Contains(content, `model = "custom-user-model"`) {
-		t.Errorf("expected user model to be preserved, got:\n%s", content)
+	if strings.Contains(content, `profile = "databricks-proxy"`) {
+		t.Errorf("legacy root profile key must be stripped, got:\n%s", content)
+	}
+	if strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Errorf("legacy [profiles.databricks-proxy] section must be stripped, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Errorf("unrelated user section must survive migration, got:\n%s", content)
+	}
+
+	// Sibling: carries forward the legacy model value.
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "custom-user-model"`) {
+		t.Errorf("expected legacy model to be migrated into sibling file, got:\n%s", sibling)
+	}
+}
+
+func TestPatch_PreservesUserModel(t *testing.T) {
+	// Same flow as TestPatch_MigratesLegacyDatabricksProxyKeys but
+	// asserts the preserve-if-present semantics from the user's angle: a
+	// custom model in the legacy section migrates into the sibling
+	// without being overwritten by the resolved fallback.
+	initial := `profile = "databricks-proxy"
+
+[profiles.databricks-proxy]
+model_provider = "databricks-proxy"
+model = "custom-user-model"
+`
+	m, _ := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-5",
+		ModelExplicit: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "custom-user-model"`) {
+		t.Errorf("expected user model to be preserved in sibling, got:\n%s", sibling)
 	}
 }
 
@@ -134,14 +209,8 @@ func TestPatch_OverridesModelWhenExplicit(t *testing.T) {
 [profiles.databricks-proxy]
 model_provider = "databricks-proxy"
 model = "custom-user-model"
-
-[model_providers.databricks-proxy]
-name = "Databricks Proxy"
-base_url = "http://old-proxy:1234"
-api_key = "databricks-proxy"
-wire_api = "responses"
 `
-	m, configPath := setup(t, initial)
+	m, _ := setup(t, initial)
 
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
@@ -152,17 +221,53 @@ wire_api = "responses"
 		t.Fatal(err)
 	}
 
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `model = "databricks-gpt-5-4-mini"`) {
-		t.Errorf("expected model to be overridden to databricks-gpt-5-4-mini, got:\n%s", content)
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "databricks-gpt-5-4-mini"`) {
+		t.Errorf("expected explicit --model to win in sibling, got:\n%s", sibling)
 	}
-	if strings.Contains(content, `model = "custom-user-model"`) {
-		t.Errorf("expected custom-user-model to be replaced, got:\n%s", content)
+	if strings.Contains(sibling, `model = "custom-user-model"`) {
+		t.Errorf("expected custom-user-model to be replaced in sibling, got:\n%s", sibling)
 	}
 }
 
-func TestRestore_RemovesAddedKeys(t *testing.T) {
-	// Start with a config that has NO databricks-proxy sections.
+// TestPatch_PreservesExistingSiblingModel verifies that if a sibling file
+// already exists (user edited it, or a prior session wrote it), its model
+// value is preserved when ModelExplicit=false.
+func TestPatch_PreservesExistingSiblingModel(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
+
+	// Seed sibling with a user-set model.
+	if err := os.WriteFile(siblingPath, []byte(`model_provider = "databricks-proxy"
+model = "user-picked-model"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(configPath)
+	if err := m.Backup(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-5",
+		ModelExplicit: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "user-picked-model"`) {
+		t.Errorf("expected existing sibling model to be preserved, got:\n%s", sibling)
+	}
+}
+
+func TestRestore_RemovesAddedSections(t *testing.T) {
+	// Start with a config that has NO databricks-proxy sections AND no
+	// sibling file. Restore must remove everything we added.
 	initial := `[projects.myapp]
 sandbox_permissions = "full-auto"
 `
@@ -176,35 +281,40 @@ sandbox_permissions = "full-auto"
 		t.Fatal(err)
 	}
 
-	// Verify patch added sections.
+	// Verify patch added the provider section + sibling file.
 	content := readConfig(t, configPath)
-	if !strings.Contains(content, "[profiles.databricks-proxy]") {
-		t.Fatal("patch should have added profiles section")
+	if !strings.Contains(content, "[model_providers.databricks-proxy]") {
+		t.Fatal("patch should have added provider section")
+	}
+	if _, err := os.Stat(m.SiblingPath()); err != nil {
+		t.Fatalf("patch should have created sibling file: %v", err)
 	}
 
-	// Restore.
 	if err := m.Restore(); err != nil {
 		t.Fatal(err)
 	}
 
 	content = readConfig(t, configPath)
-	if strings.Contains(content, "[profiles.databricks-proxy]") {
-		t.Error("expected [profiles.databricks-proxy] to be removed after restore")
-	}
 	if strings.Contains(content, "[model_providers.databricks-proxy]") {
 		t.Error("expected [model_providers.databricks-proxy] to be removed after restore")
-	}
-	if strings.Contains(content, `profile = "databricks-proxy"`) {
-		t.Error("expected profile root key to be removed after restore")
 	}
 	// User section must survive.
 	if !strings.Contains(content, "[projects.myapp]") {
 		t.Error("expected [projects.myapp] to survive restore")
 	}
+	// Sibling file must be gone (it didn't exist pre-patch).
+	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
+		t.Error("expected sibling file to be removed after restore")
+	}
 }
 
-func TestRestore_RestoresOriginalValues(t *testing.T) {
-	initial := `profile = "myprofile"
+// TestRestore_PutsBackLegacyKeys verifies that when Patch strips legacy
+// `profile = "databricks-proxy"` and `[profiles.databricks-proxy]` from
+// base config, Restore puts them back. Symmetric round-trip — important
+// when a pre-v0.7 databricks-codex left state behind and the user is just
+// running a single session of the new wrapper.
+func TestRestore_PutsBackLegacyKeys(t *testing.T) {
+	initial := `profile = "databricks-proxy"
 
 [profiles.databricks-proxy]
 model_provider = "databricks-proxy"
@@ -230,20 +340,26 @@ sandbox_permissions = "full-auto"
 		t.Fatal(err)
 	}
 
-	// Restore.
 	if err := m.Restore(); err != nil {
 		t.Fatal(err)
 	}
 
 	content := readConfig(t, configPath)
-	if !strings.Contains(content, `profile = "myprofile"`) {
-		t.Errorf("expected original profile to be restored, got:\n%s", content)
+	if !strings.Contains(content, `profile = "databricks-proxy"`) {
+		t.Errorf("expected legacy root profile to be restored, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Errorf("expected legacy [profiles.databricks-proxy] to be restored, got:\n%s", content)
 	}
 	if !strings.Contains(content, `model = "original-model"`) {
-		t.Errorf("expected original model to be restored, got:\n%s", content)
+		t.Errorf("expected original model to be restored inside legacy section, got:\n%s", content)
 	}
 	if !strings.Contains(content, "[projects.myapp]") {
 		t.Errorf("expected user section preserved, got:\n%s", content)
+	}
+	// Sibling file must be gone (it didn't exist pre-patch).
+	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
+		t.Error("expected sibling file to be removed after restore")
 	}
 }
 
@@ -287,6 +403,46 @@ shown = true
 	}
 }
 
+// TestRestore_PreservesExistingSibling verifies that if a sibling file
+// existed pre-patch (e.g. user maintains one), Restore puts its original
+// content back byte-for-byte, not just deletes it.
+func TestRestore_PreservesExistingSibling(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
+	originalSibling := `model_provider = "databricks-proxy"
+model = "user-handcrafted"
+# user comment
+`
+	if err := os.WriteFile(siblingPath, []byte(originalSibling), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(configPath)
+	if err := m.Backup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(siblingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != originalSibling {
+		t.Errorf("sibling restore did not preserve content byte-for-byte\nwant:\n%s\ngot:\n%s", originalSibling, string(got))
+	}
+}
+
 func TestRestore_NoOriginalFile(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
@@ -311,18 +467,21 @@ func TestRestore_NoOriginalFile(t *testing.T) {
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
 		t.Error("expected config.toml to be removed after restore when it didn't exist before")
 	}
+	if _, err := os.Stat(m.SiblingPath()); !os.IsNotExist(err) {
+		t.Error("expected sibling file to be removed after restore when it didn't exist before")
+	}
 }
 
 func TestPatch_RespectsRootLevelModel(t *testing.T) {
-	initial := `model = databricks-gpt-5-3
+	initial := `model = "databricks-gpt-5-3"
 
-[projects./Users/me/myproject]
-trust_level = trusted
+[projects."/Users/me/myproject"]
+trust_level = "trusted"
 `
-	m, configPath := setup(t, initial)
+	m, _ := setup(t, initial)
 
-	// No --model flag (ModelExplicit=false), no model in [profiles.databricks-proxy].
-	// Should pick up the root-level model.
+	// No --model flag (ModelExplicit=false), no model in sibling.
+	// Should pick up the root-level model and write it into sibling.
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-5",
@@ -332,24 +491,23 @@ trust_level = trusted
 		t.Fatal(err)
 	}
 
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `model = "databricks-gpt-5-3"`) {
-		t.Errorf("expected root-level model to be carried into profile section, got:\n%s", content)
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "databricks-gpt-5-3"`) {
+		t.Errorf("expected root-level model to be carried into sibling, got:\n%s", sibling)
 	}
-	if strings.Contains(content, `model = "databricks-gpt-5-5"`) {
-		t.Errorf("expected fallback model NOT to be used when root-level model exists, got:\n%s", content)
+	if strings.Contains(sibling, `model = "databricks-gpt-5-5"`) {
+		t.Errorf("expected fallback model NOT to be used when root-level model exists, got:\n%s", sibling)
 	}
 }
 
 func TestPatch_RootLevelModelOverriddenByExplicitFlag(t *testing.T) {
-	initial := `model = databricks-gpt-5-3
+	initial := `model = "databricks-gpt-5-3"
 
-[projects./Users/me/myproject]
-trust_level = trusted
+[projects."/Users/me/myproject"]
+trust_level = "trusted"
 `
-	m, configPath := setup(t, initial)
+	m, _ := setup(t, initial)
 
-	// --model flag explicitly set: should override root-level model.
 	err := m.Patch(PatchConfig{
 		ProxyURL:      "http://127.0.0.1:9999",
 		Model:         "databricks-gpt-5-4-mini",
@@ -359,9 +517,9 @@ trust_level = trusted
 		t.Fatal(err)
 	}
 
-	content := readConfig(t, configPath)
-	if !strings.Contains(content, `model = "databricks-gpt-5-4-mini"`) {
-		t.Errorf("expected explicit --model to win over root-level model, got:\n%s", content)
+	sibling := readSibling(t, m)
+	if !strings.Contains(sibling, `model = "databricks-gpt-5-4-mini"`) {
+		t.Errorf("expected explicit --model to win over root-level model in sibling, got:\n%s", sibling)
 	}
 }
 
@@ -405,7 +563,6 @@ func TestPatch_WithOTELMetricsOnly(t *testing.T) {
 	if !strings.Contains(content, `metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
 		t.Errorf("expected metrics_exporter key in [otel] section, got:\n%s", content)
 	}
-	// Specifically: there should be no bare `exporter = { otlp-http = { endpoint = "http://...logs"`
 	if strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
 		t.Errorf("expected no logs exporter when only metrics endpoint provided, got:\n%s", content)
 	}
@@ -450,13 +607,9 @@ func TestPatch_NoOTELSectionWhenBothEmpty(t *testing.T) {
 	}
 }
 
-// TestPatch_OTELReWriteAddsMetricsExporter exercises the EnsureConfig regression
-// flagged in PR review: an existing [otel] section with only `exporter` should
-// gain `metrics_exporter` on a subsequent Patch with both endpoints set.
 func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	m, configPath := setup(t, "")
 
-	// First patch: logs only.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:         "http://127.0.0.1:9999",
 		Model:            "databricks-gpt-5-5",
@@ -465,7 +618,6 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Second patch: same proxy URL, now with metrics too.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
@@ -484,13 +636,9 @@ func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
 	}
 }
 
-// TestPatch_RemovesOTELSectionWhenEndpointsEmpty exercises the --no-otel
-// regression: a previously-written [otel] section must be removed entirely
-// when a subsequent Patch comes in with both endpoints empty.
 func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	m, configPath := setup(t, "")
 
-	// First patch: OTel enabled.
 	if err := m.Patch(PatchConfig{
 		ProxyURL:            "http://127.0.0.1:9999",
 		Model:               "databricks-gpt-5-5",
@@ -505,7 +653,6 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 		t.Fatalf("setup error: expected [otel] section after first patch, got:\n%s", before)
 	}
 
-	// Second patch: OTel disabled (both endpoints empty). Section must be gone.
 	if err := m.Patch(PatchConfig{
 		ProxyURL: "http://127.0.0.1:9999",
 		Model:    "databricks-gpt-5-5",
@@ -523,9 +670,9 @@ func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
 	if strings.Contains(after, "metrics_exporter") {
 		t.Errorf("expected no stale metrics_exporter line after removal, got:\n%s", after)
 	}
-	// And [profiles.databricks-proxy] should still be intact.
-	if !strings.Contains(after, "[profiles.databricks-proxy]") {
-		t.Errorf("expected [profiles.databricks-proxy] to survive [otel] removal, got:\n%s", after)
+	// Provider section should survive.
+	if !strings.Contains(after, "[model_providers.databricks-proxy]") {
+		t.Errorf("expected [model_providers.databricks-proxy] to survive [otel] removal, got:\n%s", after)
 	}
 }
 
@@ -557,8 +704,12 @@ func TestRestoreFromBackup(t *testing.T) {
 
 	original := `profile = "myprofile"
 `
-	os.WriteFile(backupPath, []byte(original), 0o600)
-	os.WriteFile(configPath, []byte(`profile = "databricks-proxy"`), 0o600)
+	if err := os.WriteFile(backupPath, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`profile = "databricks-proxy"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	m := NewManager(configPath)
 	restored := m.RestoreFromBackup()
@@ -573,5 +724,37 @@ func TestRestoreFromBackup(t *testing.T) {
 
 	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
 		t.Error("expected backup file to be removed after restore")
+	}
+}
+
+// TestRestoreFromBackup_RemovesOrphanSibling verifies that crash recovery
+// also removes a sibling file that the crashed session wrote (no backup
+// means the sibling wasn't there before).
+func TestRestoreFromBackup_RemovesOrphanSibling(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	siblingPath := filepath.Join(dir, SiblingProfileName+".config.toml")
+	backupPath := configPath + ".databricks-codex-backup"
+
+	// Crashed session left: original backed up, sibling written, no sibling backup.
+	if err := os.WriteFile(backupPath, []byte(`# original
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`# patched
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(siblingPath, []byte(`model_provider = "databricks-proxy"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(configPath)
+	if !m.RestoreFromBackup() {
+		t.Error("expected RestoreFromBackup to return true")
+	}
+	if _, err := os.Stat(siblingPath); !os.IsNotExist(err) {
+		t.Error("expected orphan sibling file to be removed during crash recovery")
 	}
 }

--- a/process.go
+++ b/process.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/IceRhymers/databricks-claude/pkg/childproc"
+	"github.com/IceRhymers/databricks-codex/pkg/tomlconfig"
 )
 
 // OTEL environment variable keys for Codex telemetry. These are set as env
@@ -29,12 +30,44 @@ var otelKeys = []string{
 // URL are configured via config.toml (not environment variables).
 // DATABRICKS_CODEX_MANAGED=1 is injected so that child codex sessions skip
 // headless-ensure/release hooks (prevents double-firing).
+//
+// Codex profile-v2: we prepend `--profile databricks-proxy` so that the
+// sibling file (`~/.codex/databricks-proxy.config.toml`) becomes the
+// active layer on top of base config. The flag is NOT injected if the
+// user already passed their own `--profile` — they get the last word.
 func RunCodex(ctx context.Context, args []string) (int, error) {
 	os.Setenv("DATABRICKS_CODEX_MANAGED", "1")
 	return childproc.Run(ctx, childproc.Config{
 		BinaryName: "codex",
-		Args:       args,
+		Args:       withProfileFlag(args),
 	})
+}
+
+// withProfileFlag returns args with `--profile <SiblingProfileName>`
+// prepended unless the user already supplied a profile selector.
+func withProfileFlag(args []string) []string {
+	if hasUserProfileFlag(args) {
+		return args
+	}
+	return append([]string{"--profile", tomlconfig.SiblingProfileName}, args...)
+}
+
+// hasUserProfileFlag scans codex-bound args for any spelling of the
+// profile selector. Stops at `--` so flags after the explicit separator
+// (which codex treats as positional) don't count.
+func hasUserProfileFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "--profile" || a == "-p" {
+			return true
+		}
+		if len(a) > len("--profile=") && a[:len("--profile=")] == "--profile=" {
+			return true
+		}
+	}
+	return false
 }
 
 // ForwardSignals sets up SIGINT/SIGTERM forwarding from the parent to cmd's

--- a/process_test.go
+++ b/process_test.go
@@ -43,3 +43,55 @@ func TestOtelKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestWithProfileFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty args get profile prepended",
+			in:   nil,
+			want: []string{"--profile", "databricks-proxy"},
+		},
+		{
+			name: "regular codex args get profile prepended",
+			in:   []string{"exec", "hello"},
+			want: []string{"--profile", "databricks-proxy", "exec", "hello"},
+		},
+		{
+			name: "user --profile is respected",
+			in:   []string{"--profile", "work", "exec"},
+			want: []string{"--profile", "work", "exec"},
+		},
+		{
+			name: "user --profile=value is respected",
+			in:   []string{"--profile=work", "exec"},
+			want: []string{"--profile=work", "exec"},
+		},
+		{
+			name: "user -p short form is respected",
+			in:   []string{"-p", "work"},
+			want: []string{"-p", "work"},
+		},
+		{
+			name: "profile after -- separator does not count",
+			in:   []string{"exec", "--", "--profile", "work"},
+			want: []string{"--profile", "databricks-proxy", "exec", "--", "--profile", "work"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := withProfileFlag(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("element %d: got %q, want %q (full: %v)", i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Codex shipped profile-v2 and made the legacy profile layout a hard error. Existing databricks-codex installs were broken in the Codex GUI with:

```
Failed to resolve feature override precedence: legacy `profile = "databricks-proxy"` config is no longer supported; use `--profile databricks-proxy` with `databricks-proxy.config.toml` instead
```

This PR migrates `pkg/tomlconfig` to the profile-v2 layout and prepends `--profile databricks-proxy` when launching codex.

Fixes #98.

## Changes

**`pkg/tomlconfig/tomlconfig.go`** — surgical patcher now writes the v2 layout:
- Base `~/.codex/config.toml` keeps `[model_providers.databricks-proxy]` + `[otel]` only.
- New sibling `~/.codex/databricks-proxy.config.toml` owns `model_provider` + `model` (the profile-v2 layer).
- Legacy `profile = "databricks-proxy"` + `[profiles.databricks-proxy]` from prior installs are **stripped on Patch** (so the Codex GUI loader accepts the config) and **restored on Restore** (round-trip safe).
- Sibling file has its own backup / atomic write / crash-recovery path symmetric to base.
- Model resolution chain preserved: sibling-existing → legacy-section migration → root-level → fallback. Existing `[profiles.databricks-proxy] model = "..."` values migrate forward into the sibling file automatically.

**`process.go`** — `RunCodex` now prepends `--profile databricks-proxy` to child args unless the user already passed `--profile` / `--profile=` / `-p` (their flag wins).

**Tests** — `pkg/tomlconfig/tomlconfig_test.go` rewritten for v2 layout. New coverage:
- `TestPatch_WritesV2Layout` — asserts base has provider section but no legacy keys, sibling has `model_provider` + `model`.
- `TestPatch_MigratesLegacyDatabricksProxyKeys` — upgrade-from-prior-install path: legacy keys stripped, model value migrated forward.
- `TestPatch_PreservesExistingSiblingModel` — preserve-if-present for sibling-owned model value.
- `TestRestore_PutsBackLegacyKeys` — symmetric round-trip when base config had legacy keys at Backup time.
- `TestRestore_PreservesExistingSibling` — byte-for-byte restore of a user-maintained sibling file.
- `TestRestoreFromBackup_RemovesOrphanSibling` — crash recovery removes the sibling file from an aborted session that had no original.
- `TestWithProfileFlag` in `process_test.go` — table-driven, covers user override paths.

## Breaking

`fix!:` — on-disk contract with `~/.codex/` changes:
- We now own a second file (`databricks-proxy.config.toml`).
- Existing legacy keys we previously wrote are auto-migrated forward; users upgrading from a pre-v0.7 install pick up the new layout transparently on next launch.
- Child codex argv now starts with `--profile databricks-proxy` (user `--profile` still wins).

release-please will cut this as a major bump (1.x → 2.0).

## Acceptance

- [x] `go build ./...` clean
- [x] `make lint` (`go vet ./...`) clean
- [x] `make test` — all packages pass (proxy integration + tomlconfig + cmd + process tests)
- [x] No legacy `profile = "databricks-proxy"` / `[profiles.databricks-proxy]` written to base config.toml
- [x] Sibling file written at `~/.codex/databricks-proxy.config.toml`
- [x] Legacy-keys migration: keys stripped, model value carried into sibling
- [x] Restore puts both files back; user-authored content survives byte-for-byte

## References

- Upstream rejection (core): https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs#L2606-L2613
- Upstream rejection (loader v2): https://github.com/openai/codex/blob/main/codex-rs/config/src/loader/mod.rs#L240-L247
- App-server error wrap: https://github.com/openai/codex/blob/main/codex-rs/app-server/src/request_processors/config_processor.rs#L271-L274
- Profile-v2 docs: https://developers.openai.com/codex/config-advanced#profiles
